### PR TITLE
reset password controller

### DIFF
--- a/app/controllers/google_auth_controller.rb
+++ b/app/controllers/google_auth_controller.rb
@@ -5,6 +5,8 @@ class GoogleAuthController < ApplicationController
     email = request.env['omniauth.auth']['info']['email']
     if email.end_with? '@digital.cabinet-office.gov.uk'
       session['email'] = email
+      session['name'] = request.env['omniauth.auth']['info']['name']
+
       redirect_to index_path
     else
       redirect_to error_bad_email_path

--- a/app/controllers/reset_password_controller.rb
+++ b/app/controllers/reset_password_controller.rb
@@ -1,0 +1,20 @@
+class ResetPasswordController < ApplicationController
+  def reset_password
+    @form = UserForm.new({})
+  end
+
+  def post
+    requester_name = session.fetch('name')
+    requester_email = session.fetch('email')
+
+    pull_request_url = GithubService.new.create_reset_user_email_pull_request(requester_name, requester_email) || 'error-creating-pull-request'
+
+    session['pull_request_url'] = pull_request_url
+
+    notify_service = NotifyService.new
+    notify_service.reset_password_email_support(requester_name, requester_email, pull_request_url)
+    notify_service.reset_password_email_user(requester_name, requester_email, pull_request_url)
+
+    redirect_to confirmation_reset_password_path
+  end
+end

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -107,4 +107,38 @@ class NotifyService
       }
     )
   end
+
+  def reset_password_email_user(requester_name, requester_email, pull_request_url)
+    unless @notify_api_key
+      Rails.logger.warn 'Warning: no NOTIFY_API_KEY set. Skipping emails.'
+      return nil
+    end
+
+    client = Notifications::Client.new(@notify_api_key)
+    client.send_email(
+      email_address: requester_email,
+      template_id: 'afff4178-f7bc-4152-9200-d8bf614d7073',
+      personalisation: {
+        pull_request_url: pull_request_url
+      }
+    )
+  end
+
+  def reset_password_email_support(requester_name, requester_email, pull_request_url)
+    unless @notify_api_key
+      Rails.logger.warn 'Warning: no NOTIFY_API_KEY set. Skipping emails.'
+      return nil
+    end
+
+    client = Notifications::Client.new(@notify_api_key)
+    client.send_email(
+      email_address: 'gds-aws-account-management@digital.cabinet-office.gov.uk',
+      template_id: 'a4bdbc15-d899-47d9-867e-4e240c1687f9',
+      personalisation: {
+        requester_name: requester_name,
+        requester_email: requester_email,
+        pull_request_url: pull_request_url
+      }
+    )
+  end
 end

--- a/app/views/confirmation/reset_password.html.erb
+++ b/app/views/confirmation/reset_password.html.erb
@@ -1,0 +1,24 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+
+    <div class="govuk-box-highlight">
+      <h1 class="heading-xlarge">
+        Application complete
+      </h1>
+      <p class="font-large">
+        Your reference number is <br>
+        <strong class="bold"><%= @pull_request_url.sub('https://github.com/', '') %></strong>
+      </p>
+    </div>
+
+    <h2 class="heading-medium">
+      What happens next?
+    </h2>
+    <p>
+      Reliability engineering will reset your gds-users IAM password. They'll send you an email once the work is complete.
+    </p>
+    <p>
+      Contact the team on slack channel <a href="https://gds.slack.com/messages/CAD6NP598">#reliability-eng</a> for support.
+    </p>
+  </div>
+</div>

--- a/app/views/index/index.html.erb
+++ b/app/views/index/index.html.erb
@@ -18,6 +18,10 @@
       <p>
         <a href="<%= remove_user_path %>" class="button button-destructive">Request user removal</a>
       </p>
+      <p>If you need to reset your AWS password, you can do that here as well.</p>
+      <p>
+        <a href="<%= reset_password_path %>" class="button">Request password reset</a>
+      </p>
       <h2 class="heading-medium">Request a new AWS account</h2>
       <p>Teams can use multiple AWS accounts to provide isolation between workloads. For example having separate production and test environments.</p>
       <p>See <a href="https://reliability-engineering.cloudapps.digital/iaas.html#create-aws-accounts">how to create AWS accounts</a> in the reliability engineering docs.</p>

--- a/app/views/reset_password/reset_password.html.erb
+++ b/app/views/reset_password/reset_password.html.erb
@@ -1,0 +1,16 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <a href="<%= index_path %>" class="link-back">Back</a>
+    <h1 class="heading-large">Reset your AWS password</h1>
+    <p>If you no longer know your <code>gds-users</code> IAM user password, you can use this button to request that it be reset.</p>
+    <p>Resets are not instantaneous; they must be reviewed first to prevent abuse.</p>
+    <p>You can only request a password reset for yourself.</p>
+
+    <%= form_for @form, url: reset_password_path, html: { novalidate: true } do |f| %>
+        <div>
+          <%= f.submit 'Reset my password', class: 'button' %>
+        </div>
+    <% end %>
+  </div>
+</div>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,9 @@ Rails.application.routes.draw do
   get '/remove-user', to: 'remove_user#remove_user', as: :remove_user
   post '/remove-user', to: 'remove_user#post'
 
+  get '/reset-password', to: 'reset_password#reset_password', as: :reset_password
+  post '/reset-password', to: 'reset_password#post'
+
   get '/account-details', to: 'account_details#account_details', as: :account_details
   post '/account-details', to: 'account_details#post'
 


### PR DESCRIPTION
This allows users to request a password reset to their own account.
They will have had to log in using google auth to perform this
request, and they will only be able to reset their own password (not
those of other users).

I feel like google auth is a better authentication mechanism than
hazing people with shoe pictures :)

The actual reset happens using the concourse gitops flow.  This merely
piggybacks on the existing infrastructure: it opens a PR to
`aws-user-management-account-users` updating the magic text file that
will kick off concourse to reset the password.

I haven't actually been able to test this at all, because I can't get
google auth to work locally; so I'd appreciate help from someone who
has some idea how to test it.  Or we could just :cowboy_hat_face:
deploy it and see if it breaks.  It's not a particularly high traffic
app after all.