### PR TITLE
Test UserController more thorougly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'notifications-ruby-client', '~> 3.1'
 gem 'lograge', '~> 0.10.0'
 gem 'logstash-event', '~> 1.2.02'
 gem 'gds_metrics', groups: [:production]
+gem 'webmock', '~> 3.5'
 
 group :test do
   gem 'rack_session_access', '~> 0.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,8 @@ GEM
     arel (9.0.0)
     builder (3.2.3)
     concurrent-ruby (1.1.5)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.4)
     dotenv (2.7.1)
     dotenv-rails (2.7.1)
@@ -69,6 +71,7 @@ GEM
       sass (>= 3.2.0)
     govuk_template (0.26.0)
       rails (>= 3.1)
+    hashdiff (0.3.9)
     hashie (3.6.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
@@ -155,6 +158,7 @@ GEM
       ffi (~> 1.0)
     request_store (1.4.1)
       rack (>= 1.4)
+    safe_yaml (1.0.5)
     sass (3.7.3)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -174,6 +178,10 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    webmock (3.5.1)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -194,6 +202,7 @@ DEPENDENCIES
   omniauth-google-oauth2 (~> 0.6.1)
   rack_session_access (~> 0.2.0)
   rails (= 5.2.2.1)
+  webmock (~> 3.5)
 
 RUBY VERSION
    ruby 2.5.3p105

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,7 +1,21 @@
 require 'test_helper'
+require 'webmock'
+
+USER_MANAGEMENT_GITHUB_API = "https://api.github.com/repos/alphagov/aws-user-management-account-users"
 
 class UserControllerTest < ActionDispatch::IntegrationTest
-  setup { sign_in 'test@example.com' }
+  include WebMock::API
+
+  setup {
+    WebMock.enable!
+    set_stub_env_vars
+    sign_in 'test@example.com'
+  }
+
+  teardown {
+    WebMock.disable!
+    reset_env_vars
+  }
 
   test 'should get index' do
     get user_url
@@ -14,8 +28,73 @@ class UserControllerTest < ActionDispatch::IntegrationTest
     assert_select '.error-message', 'GDS email addresses should be a list of GDS emails'
   end
 
-  test 'should redirect on valid form' do
-    post user_url, params: { user_form: { email_list: 'test.user@digital.cabinet-office.gov.uk' } }
+  test 'should create pull request and redirect with pull_request_url in session' do
+    users_terraform_before = build_content_request(resource:[])
+    cross_account_terraform_before = build_content_request(
+      resource: { aws_iam_group_membership: { "crossaccountaccess-members" => { users: [] } } }
+    )
+    stub_create_user_github_api(
+      users_terraform_before,
+      cross_account_terraform_before,
+      "https://some-pull-request-url",
+    )
+
+    post(user_url, params: { user_form: { email_list: 'test.user@digital.cabinet-office.gov.uk' } })
+
+    users_terraform_after = assert_content_updated("/terraform/gds_users.tf")
+    assert_equal(
+      [ {"aws_iam_user"=>{"test_user"=>{"name"=>"test.user@digital.cabinet-office.gov.uk", "force_destroy"=>true}}}],
+      users_terraform_after.dig('resource'))
+
+    cross_account_terraform_after = assert_content_updated("/terraform/iam_crossaccountaccess_members.tf")
+    assert_equal(
+      {"users"=>["${aws_iam_user.test_user.name}"]},
+      cross_account_terraform_after.dig('resource', 'aws_iam_group_membership', 'crossaccountaccess-members')
+    )
+
     assert_redirected_to confirmation_user_url
+    assert_equal "https://some-pull-request-url", read_from_session("pull_request_url")
+  end
+
+private
+
+  def stub_create_user_github_api(users_terraform, cross_account_terraform, resulting_pull_request_url)
+    stub_request(:get, "#{USER_MANAGEMENT_GITHUB_API}/contents/terraform/gds_users.tf").
+      to_return(status: 200, body: users_terraform, headers: {'Content-Type' => 'application/json'})
+
+    stub_request(:get, "#{USER_MANAGEMENT_GITHUB_API}/contents/terraform/iam_crossaccountaccess_members.tf").
+      to_return(status: 200, body: cross_account_terraform, headers: {'Content-Type' => 'application/json'})
+
+    stub_request(:get, "#{USER_MANAGEMENT_GITHUB_API}/commits/master").
+      to_return(status: 200, body: '{"sha":"somesha"}', headers: {'Content-Type' => 'application/json'})
+
+    stub_request(:post, "#{USER_MANAGEMENT_GITHUB_API}/git/refs").
+      to_return(status: 200, body: '{}', headers: {'Content-Type' => 'application/json'})
+
+    stub_request(:put, "#{USER_MANAGEMENT_GITHUB_API}/contents/terraform/gds_users.tf").
+      to_return(status: 200, body: '{}', headers: {'Content-Type' => 'application/json'})
+
+    stub_request(:put, "#{USER_MANAGEMENT_GITHUB_API}/contents/terraform/iam_crossaccountaccess_members.tf").
+      to_return(status: 200, body: '{}', headers: {'Content-Type' => 'application/json'})
+
+    stub_request(:post, "#{USER_MANAGEMENT_GITHUB_API}/pulls").
+      to_return(status: 200, body: '{"html_url": "' + resulting_pull_request_url + '"}', headers: {'Content-Type' => 'application/json'})
+  end
+
+  def assert_content_updated(path)
+    body = nil
+    assert_requested(:put, "#{USER_MANAGEMENT_GITHUB_API}/contents#{path}") do |req|
+      body = req.body
+      true
+    end
+    assert_not_nil body
+    body_json = assert_nothing_raised { JSON.parse(body) }
+    assert_not_nil body_json["content"]
+    content_decoded = assert_nothing_raised { Base64.decode64(body_json["content"]) }
+    return assert_nothing_raised { JSON.parse(content_decoded) }
+  end
+
+  def build_content_request(input)
+    JSON.dump(content: Base64.encode64(JSON.dump(input)))
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,15 @@ require_relative '../config/environment'
 require 'rails/test_help'
 
 class ActiveSupport::TestCase
+
+  def set_stub_env_vars
+    ENV['GITHUB_PERSONAL_ACCESS_TOKEN'] = 'SOME_VALUE'
+  end
+
+  def reset_env_vars
+    ENV.delete('GITHUB_PERSONAL_ACCESS_TOKEN')
+  end
+
   def sign_in(email)
     put ::RackSessionAccess.path, params: { data: ::RackSessionAccess.encode({ 'email' => email }) }
     follow_redirect!
@@ -11,5 +20,11 @@ class ActiveSupport::TestCase
   def set_session(email, form)
     put ::RackSessionAccess.path, params: { data: ::RackSessionAccess.encode({ 'email' => email, 'form' => form }) }
     follow_redirect!
+  end
+
+  def read_from_session(key)
+    get "#{::RackSessionAccess.path}.raw"
+    session = RackSessionAccess.decode(html_document.css("pre").inner_html)
+    session[key]
   end
 end


### PR DESCRIPTION
When I first wrote this project I couldn't be bothered to test anything
that had any side effects (like the GitHub and GOV.UK Notify API calls).

Instead, I made the services that talk to these things silently fail if
they weren't configured. This made it look like the tests were working,
but actually they were testing an error path that just happened to look
a bit like a success, because of shitty error handling.

This shitty error handling made it all the way out into the user
interface, resulting in the increasingly well known:

Success: your reference number is `error-creating-pull-request`

page.

I'd like to start refactoring this project and fixing the crappy error
handling, but I'm not comfortable making changes without proper test
coverage.

This commit adds [webmock](https://github.com/bblimke/webmock) and uses
it to mock out requests to github. This allows us to be much more
thorough about our assertions, including testing that:

- the controller updated the contents of the two terraform files in the
  correct way (to add the user)
- the controller redirected to the confirmation page
- the pull request URL we get back from github is stored in session

I had to do a couple of gross things to get this to work:

- in `read_from_session` we're using
  [rack_session_access](https://github.com/railsware/rack_session_access),
  to get the session. This basically renders an encoded version of the
  session in a `pre` tag, which we then have to fish out and decode.
  This is basically what rack_session_access does in its [capybara helper](https://github.com/railsware/rack_session_access/blob/01675f3eb622f539861904dc01a395d51721b429/lib/rack_session_access/capybara.rb#L13-L18).
- in `assert_content_updated` I had to do some slightly unpleasent
  closure things to capture the body of the request so I could make
  assertions about the content.

If we're happy in general with this approach, it can be extended to the
other controllers. At which point we should be able to do some more
confident refactoring.