### PR TITLE
Improve integration tests

### DIFF
--- a/test/controllers/check_your_answers_controller_test.rb
+++ b/test/controllers/check_your_answers_controller_test.rb
@@ -1,16 +1,70 @@
 require 'test_helper'
+require 'webmock'
+
+ACCOUNT_MANAGEMENT_GITHUB_API = "https://api.github.com/repos/alphagov/aws-billing-account"
 
 class CheckYourAnswersControllerTest < ActionDispatch::IntegrationTest
-  setup { set_session 'test@example.com', 'account_name' => 'some-name', 'programme' => 'GOV.UK' }
+  include WebMock::API
+  setup {
+    WebMock.enable!
+    set_stub_env_vars
+    set_session(
+      'test@example.com',
+      'account_name' => 'some-name',
+      'programme' => 'GOV.UK',
+      'account_description' => 'some account description',
+    )
+  }
+
+  teardown {
+    WebMock.reset!
+    WebMock.disable!
+    reset_env_vars
+  }
 
   test 'should get index' do
     get check_your_answers_url
     assert_response :success
   end
 
-  test 'should redirect on valid session' do
+  test 'should raise a PR for a new account and redirect with the PR url in session' do
+    accounts_terraform_before = build_content_request({ resource: [] })
+    stub_create_account_github_api(
+      accounts_terraform_before,
+      "https://some-new-account-pull-request-url")
     post check_your_answers_url
+
+    accounts_terraform_after = assert_content_updated(ACCOUNT_MANAGEMENT_GITHUB_API, '/terraform/accounts.tf')
+    assert_equal(
+      {
+        "some-name" => {
+          "name" => "some-name",
+          "email" => "aws-root-accounts+some-name@digital.cabinet-office.gov.uk",
+          "role_name" => "bootstrap",
+          "iam_user_access_to_billing" => "ALLOW"
+        }
+      },
+      accounts_terraform_after['resource'][0]['aws_organizations_account']
+    )
+
     assert_redirected_to confirmation_account_url
+    assert_equal "https://some-new-account-pull-request-url", read_from_session("pull_request_url")
   end
 
+  def stub_create_account_github_api(accounts_terraform, resulting_pull_request_url)
+    stub_request(:get, "#{ACCOUNT_MANAGEMENT_GITHUB_API}/commits/master").
+      to_return(status: 200, body: '{"sha":"somesha"}', headers: {'Content-Type' => 'application/json'})
+
+    stub_request(:post, "#{ACCOUNT_MANAGEMENT_GITHUB_API}/git/refs").
+      to_return(status: 200, body: '{}', headers: {'Content-Type' => 'application/json'})
+
+    stub_request(:get, "#{ACCOUNT_MANAGEMENT_GITHUB_API}/contents/terraform/accounts.tf").
+     to_return(status: 200, body: accounts_terraform, headers: {'Content-Type' => 'application/json'})
+
+    stub_request(:put, "#{ACCOUNT_MANAGEMENT_GITHUB_API}/contents/terraform/accounts.tf").
+      to_return(status: 200, body: '{}', headers: {'Content-Type' => 'application/json'})
+
+    stub_request(:post, "#{ACCOUNT_MANAGEMENT_GITHUB_API}/pulls").
+      to_return(status: 200, body: '{"html_url": "' + resulting_pull_request_url + '"}', headers: {'Content-Type' => 'application/json'})
+  end
 end

--- a/test/controllers/remove_users_controller_test.rb
+++ b/test/controllers/remove_users_controller_test.rb
@@ -29,7 +29,8 @@ class RemoveUserControllerTest < ActionDispatch::IntegrationTest
     assert_select '.error-message', 'GDS email addresses should be a list of GDS emails'
   end
 
-  test 'should create pull request to remove user and redirect with pull_request_url in session' do
+  test 'should create pull request to remove user, email the users and redirect with pull_request_url in session' do
+    stub_notify_emails
     users_terraform_before = build_content_request(resource: [
       {"aws_iam_user"=>{"test_user"=>{"name"=>"test.user@digital.cabinet-office.gov.uk", "force_destroy"=>true}}}
     ])
@@ -52,6 +53,12 @@ class RemoveUserControllerTest < ActionDispatch::IntegrationTest
     assert_equal(
       [],
       cross_account_terraform_after.dig('resource', 'aws_iam_group_membership', 'crossaccountaccess-members', 'users')
+    )
+    emails = assert_notify_emails_sent
+    assert_equal 2, emails.length
+    assert_equal(
+      %w(gds-aws-account-management@digital.cabinet-office.gov.uk test@example.com).to_set,
+      emails.map{|e|e['email_address']}.to_set
     )
 
     assert_redirected_to confirmation_remove_user_url

--- a/test/controllers/remove_users_controller_test.rb
+++ b/test/controllers/remove_users_controller_test.rb
@@ -1,7 +1,22 @@
 require 'test_helper'
+require 'webmock'
+
+USER_MANAGEMENT_GITHUB_API = "https://api.github.com/repos/alphagov/aws-user-management-account-users"
 
 class RemoveUserControllerTest < ActionDispatch::IntegrationTest
-  setup { sign_in 'test@example.com' }
+  include WebMock::API
+
+  setup {
+    WebMock.enable!
+    set_stub_env_vars
+    sign_in 'test@example.com'
+  }
+
+  teardown {
+    WebMock.reset!
+    WebMock.disable!
+    reset_env_vars
+  }
 
   test 'should get index' do
     get remove_user_url
@@ -14,8 +29,68 @@ class RemoveUserControllerTest < ActionDispatch::IntegrationTest
     assert_select '.error-message', 'GDS email addresses should be a list of GDS emails'
   end
 
-  test 'should redirect on valid form' do
+  test 'should create pull request to remove user and redirect with pull_request_url in session' do
+    users_terraform_before = build_content_request(resource: [
+      {"aws_iam_user"=>{"test_user"=>{"name"=>"test.user@digital.cabinet-office.gov.uk", "force_destroy"=>true}}}
+    ])
+    cross_account_terraform_before = build_content_request(
+      resource: { aws_iam_group_membership: { "crossaccountaccess-members" => { users: ["${aws_iam_user.test_user.name}"] } } }
+    )
+    stub_create_user_github_api(
+      users_terraform_before,
+      cross_account_terraform_before,
+      "https://some-remove-user-pull-request-url")
+
     post remove_user_url, params: { user_form: { email_list: 'test.user@digital.cabinet-office.gov.uk' } }
+
+    users_terraform_after = assert_content_updated("/terraform/gds_users.tf")
+    assert_equal(
+      [],
+      users_terraform_after.dig('resource'))
+
+    cross_account_terraform_after = assert_content_updated("/terraform/iam_crossaccountaccess_members.tf")
+    assert_equal(
+      [],
+      cross_account_terraform_after.dig('resource', 'aws_iam_group_membership', 'crossaccountaccess-members', 'users')
+    )
+
     assert_redirected_to confirmation_remove_user_url
+    assert_equal "https://some-remove-user-pull-request-url", read_from_session("pull_request_url")
+  end
+
+  def stub_create_user_github_api(users_terraform, cross_account_terraform, resulting_pull_request_url)
+    stub_request(:get, "#{USER_MANAGEMENT_GITHUB_API}/contents/terraform/gds_users.tf").
+      to_return(status: 200, body: users_terraform, headers: {'Content-Type' => 'application/json'})
+
+    stub_request(:get, "#{USER_MANAGEMENT_GITHUB_API}/contents/terraform/iam_crossaccountaccess_members.tf").
+      to_return(status: 200, body: cross_account_terraform, headers: {'Content-Type' => 'application/json'})
+
+    stub_request(:get, "#{USER_MANAGEMENT_GITHUB_API}/commits/master").
+      to_return(status: 200, body: '{"sha":"somesha"}', headers: {'Content-Type' => 'application/json'})
+
+    stub_request(:post, "#{USER_MANAGEMENT_GITHUB_API}/git/refs").
+      to_return(status: 200, body: '{}', headers: {'Content-Type' => 'application/json'})
+
+    stub_request(:put, "#{USER_MANAGEMENT_GITHUB_API}/contents/terraform/gds_users.tf").
+      to_return(status: 200, body: '{}', headers: {'Content-Type' => 'application/json'})
+
+    stub_request(:put, "#{USER_MANAGEMENT_GITHUB_API}/contents/terraform/iam_crossaccountaccess_members.tf").
+      to_return(status: 200, body: '{}', headers: {'Content-Type' => 'application/json'})
+
+    stub_request(:post, "#{USER_MANAGEMENT_GITHUB_API}/pulls").
+      to_return(status: 200, body: '{"html_url": "' + resulting_pull_request_url + '"}', headers: {'Content-Type' => 'application/json'})
+  end
+
+  def assert_content_updated(path)
+    body = nil
+    assert_requested(:put, "#{USER_MANAGEMENT_GITHUB_API}/contents#{path}") do |req|
+      body = req.body
+      true
+    end
+    assert_not_nil body
+    body_json = assert_nothing_raised { JSON.parse(body) }
+    assert_not_nil body_json["content"]
+    content_decoded = assert_nothing_raised { Base64.decode64(body_json["content"]) }
+    return assert_nothing_raised { JSON.parse(content_decoded) }
   end
 end

--- a/test/controllers/remove_users_controller_test.rb
+++ b/test/controllers/remove_users_controller_test.rb
@@ -43,12 +43,12 @@ class RemoveUserControllerTest < ActionDispatch::IntegrationTest
 
     post remove_user_url, params: { user_form: { email_list: 'test.user@digital.cabinet-office.gov.uk' } }
 
-    users_terraform_after = assert_content_updated("/terraform/gds_users.tf")
+    users_terraform_after = assert_content_updated(USER_MANAGEMENT_GITHUB_API, "/terraform/gds_users.tf")
     assert_equal(
       [],
       users_terraform_after.dig('resource'))
 
-    cross_account_terraform_after = assert_content_updated("/terraform/iam_crossaccountaccess_members.tf")
+    cross_account_terraform_after = assert_content_updated(USER_MANAGEMENT_GITHUB_API, "/terraform/iam_crossaccountaccess_members.tf")
     assert_equal(
       [],
       cross_account_terraform_after.dig('resource', 'aws_iam_group_membership', 'crossaccountaccess-members', 'users')
@@ -79,18 +79,5 @@ class RemoveUserControllerTest < ActionDispatch::IntegrationTest
 
     stub_request(:post, "#{USER_MANAGEMENT_GITHUB_API}/pulls").
       to_return(status: 200, body: '{"html_url": "' + resulting_pull_request_url + '"}', headers: {'Content-Type' => 'application/json'})
-  end
-
-  def assert_content_updated(path)
-    body = nil
-    assert_requested(:put, "#{USER_MANAGEMENT_GITHUB_API}/contents#{path}") do |req|
-      body = req.body
-      true
-    end
-    assert_not_nil body
-    body_json = assert_nothing_raised { JSON.parse(body) }
-    assert_not_nil body_json["content"]
-    content_decoded = assert_nothing_raised { Base64.decode64(body_json["content"]) }
-    return assert_nothing_raised { JSON.parse(content_decoded) }
   end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -42,12 +42,12 @@ class UserControllerTest < ActionDispatch::IntegrationTest
 
     post(user_url, params: { user_form: { email_list: 'test.user@digital.cabinet-office.gov.uk' } })
 
-    users_terraform_after = assert_content_updated("/terraform/gds_users.tf")
+    users_terraform_after = assert_content_updated(USER_MANAGEMENT_GITHUB_API, "/terraform/gds_users.tf")
     assert_equal(
       [ {"aws_iam_user"=>{"test_user"=>{"name"=>"test.user@digital.cabinet-office.gov.uk", "force_destroy"=>true}}}],
       users_terraform_after.dig('resource'))
 
-    cross_account_terraform_after = assert_content_updated("/terraform/iam_crossaccountaccess_members.tf")
+    cross_account_terraform_after = assert_content_updated(USER_MANAGEMENT_GITHUB_API, "/terraform/iam_crossaccountaccess_members.tf")
     assert_equal(
       ["${aws_iam_user.test_user.name}"],
       cross_account_terraform_after.dig('resource', 'aws_iam_group_membership', 'crossaccountaccess-members', 'users')
@@ -80,18 +80,5 @@ private
 
     stub_request(:post, "#{USER_MANAGEMENT_GITHUB_API}/pulls").
       to_return(status: 200, body: '{"html_url": "' + resulting_pull_request_url + '"}', headers: {'Content-Type' => 'application/json'})
-  end
-
-  def assert_content_updated(path)
-    body = nil
-    assert_requested(:put, "#{USER_MANAGEMENT_GITHUB_API}/contents#{path}") do |req|
-      body = req.body
-      true
-    end
-    assert_not_nil body
-    body_json = assert_nothing_raised { JSON.parse(body) }
-    assert_not_nil body_json["content"]
-    content_decoded = assert_nothing_raised { Base64.decode64(body_json["content"]) }
-    return assert_nothing_raised { JSON.parse(content_decoded) }
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,6 +28,19 @@ class ActiveSupport::TestCase
     session[key]
   end
 
+  def assert_content_updated(repository_api, path)
+    body = nil
+    assert_requested(:put, "#{repository_api}/contents#{path}") do |req|
+      body = req.body
+      true
+    end
+    assert_not_nil body
+    body_json = assert_nothing_raised { JSON.parse(body) }
+    assert_not_nil body_json["content"]
+    content_decoded = assert_nothing_raised { Base64.decode64(body_json["content"]) }
+    return assert_nothing_raised { JSON.parse(content_decoded) }
+  end
+
   def build_content_request(input)
     JSON.dump(content: Base64.encode64(JSON.dump(input)))
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,4 +27,8 @@ class ActiveSupport::TestCase
     session = RackSessionAccess.decode(html_document.css("pre").inner_html)
     session[key]
   end
+
+  def build_content_request(input)
+    JSON.dump(content: Base64.encode64(JSON.dump(input)))
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,11 +5,13 @@ require 'rails/test_help'
 class ActiveSupport::TestCase
 
   def set_stub_env_vars
-    ENV['GITHUB_PERSONAL_ACCESS_TOKEN'] = 'SOME_VALUE'
+    ENV['GITHUB_PERSONAL_ACCESS_TOKEN'] = 'SOME_GITHUB_ACCESS_TOKEN'
+    ENV['NOTIFY_API_KEY'] = 'some_notify_access_token0-00000000-0000-0000-0000-000000000000-00000000-0000-0000-0000-000000000000'
   end
 
   def reset_env_vars
     ENV.delete('GITHUB_PERSONAL_ACCESS_TOKEN')
+    ENV.delete('NOTIFY_API_KEY')
   end
 
   def sign_in(email)
@@ -26,6 +28,21 @@ class ActiveSupport::TestCase
     get "#{::RackSessionAccess.path}.raw"
     session = RackSessionAccess.decode(html_document.css("pre").inner_html)
     session[key]
+  end
+
+  def stub_notify_emails
+    stub_request(:post, "https://api.notifications.service.gov.uk/v2/notifications/email").
+      to_return(status: 200, body: '{}', headers: {})
+  end
+
+  def assert_notify_emails_sent
+    bodies = []
+    assert_requested(:post, "https://api.notifications.service.gov.uk/v2/notifications/email", at_least_times: 1) do |req|
+      bodies.push(req.body)
+      true
+    end
+    assert_not_empty bodies
+    return assert_nothing_raised { bodies.map{|b|JSON.parse(b)} }
   end
 
   def assert_content_updated(repository_api, path)


### PR DESCRIPTION
By stubbing out the github and notify APIs we can improve our integration tests
so that they actually cover most of the desired behaviour. This won't catch if
we make a change that causes us to send bad API requests, but it will mean we can
tidy our error handling up to the point where it's not just swallowing all errors.

See the individual commits for details.