### PR TITLE
Allow sign in without Google in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Run the tests with:
 bundle exec rails test
 ```
 
-To sign in as a development user, visit <http://localhost:3000/dev-login>.
+To sign in as a development user, visit <http://localhost:3000/dev-login>. If you want to test with real Google SSO, you can [create an application in the Google Cloud Console](https://console.developers.google.com/apis/credentials).
 
 Deploying to PaaS
 -----------------

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Run the tests with:
 bundle exec rails test
 ```
 
+To sign in as a development user, visit <http://localhost:3000/dev-login>.
+
 Deploying to PaaS
 -----------------
 

--- a/app/controllers/development_controller.rb
+++ b/app/controllers/development_controller.rb
@@ -1,0 +1,9 @@
+class DevelopmentController < ApplicationController
+  skip_before_action :authenticate
+
+  def dev_login
+    session['name'] = 'Example Developer'
+    session['email'] = 'example-developer@digital.cabinet-office.gov.uk'
+    redirect_to index_path
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,4 +30,8 @@ Rails.application.routes.draw do
 
   get '/auth/google_oauth2/callback', to: 'google_auth#callback'
   get '/auth/google_oauth2/error/bad-email', to: 'google_auth#error_bad_email', as: :error_bad_email
+
+  if Rails.env.development?
+    get '/dev-login' => 'development#dev_login'
+  end
 end


### PR DESCRIPTION
Most of this app needs an authenticated user, but it's not trivial to set up Google SSO locally. This PR adds a magic URL in development that allows developers to quickly sign in as a test user. Because we only use Google SSO for login, this enables devs to test most of the functionality.

<img width="1355" alt="Screen Shot 2019-06-11 at 11 29 07" src="https://user-images.githubusercontent.com/233676/59264939-277de800-8c3c-11e9-8725-a6a249218330.png">
