### PR TITLE
Add the trust relationship in the PR for the new account

### DIFF
--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -42,11 +42,14 @@ Co-authored-by: #{name} <#{email}>",
       )
 
       admin_users_arns = []
-      admin_users.each do |email|
-        admin_users_arns.append "arn:aws:iam::622626885786:user/#{email}"
+      if ! admin_users.nil?
+        admin_users.each do |email|
+          admin_users_arns.append "arn:aws:iam::622626885786:user/#{email}"
+        end
       end
-        pr_text = <<-PR_TEXT
-        "Account requested using gds-request-an-aws-account.cloudapps.digital by #{email}
+
+      pr_text = <<-PR_TEXT
+      Account requested using gds-request-an-aws-account.cloudapps.digital by #{email}
 
 Description:
 #{account_description_quote}


### PR DESCRIPTION
This is in order to reduce the amount of copying and pasting necessary
to create a new account.