### PR TITLE
BAU: Fix multi-tenant Concourse's URL address

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To sign in as a development user, visit <http://localhost:3000/dev-login>. If yo
 Deploying to PaaS
 -----------------
 
-This is continuously deployed from master by the [multi-tenant Concourse](https://cd.gds-reliabilty.engineering) via the [internal-apps pipeline in the tech-ops repo](https://github.com/alphagov/tech-ops/blob/master/reliability-engineering/pipelines/internal-apps.yml).
+This is continuously deployed from master by the [multi-tenant Concourse](https://cd.gds-reliability.engineering) via the [internal-apps pipeline in the tech-ops repo](https://github.com/alphagov/tech-ops/blob/master/reliability-engineering/pipelines/internal-apps.yml).
 
 
 To deploy to a separate route (e.g. for testing / previewing changes) you can push to PaaS manually:


### PR DESCRIPTION
When I click on the link, I get cd.gds-reliabilty.engineering’s server IP address could not be found. This change corrects multi-tenant Concourse's URL address.

Author: @adityapahuja