### PR TITLE
Fix name of "Co-authored-by" author when a user is deleted

### DIFF
--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -164,7 +164,7 @@ Co-authored-by: #{name} <#{requester_email}>",
 
 #{email_list}
 
-Co-authored-by: #{name} <#{requester_email}>",
+Co-authored-by: #{requester_name} <#{requester_email}>",
         users_contents.sha,
         new_users_contents,
         branch: new_branch_name


### PR DESCRIPTION
- Noticed this was mismatched between the name of the _requestor_ and
  the name of the _person to be deleted_. The attribution to the person
  who raised the request still worked, because "Co-authored-by" goes by
  the email address, but it looked weird.
- Example: https://github.com/alphagov/aws-user-management-account-users/pull/378.