### PR TITLE
Add Softwire as an allowed gds-users domain

### DIFF
--- a/app/lib/email_validator.rb
+++ b/app/lib/email_validator.rb
@@ -1,14 +1,18 @@
 module EmailValidator
+
+  # which allowed domains can sign in to the request an account service
   def self.email_is_allowed?(email)
     return true if email.end_with? '@digital.cabinet-office.gov.uk'
     return true if email.end_with? '@cabinetoffice.gov.uk'
     false
   end
 
+  # which domains are allowed to be requested for a gds-users account
   def self.allowed_emails_regexp
     Regexp.union(
-      /\A([a-z.\-]+@digital\.cabinet-office\.gov\.uk,?\s*)+\z/,
-      /\A([a-z.\-]+@cabinetoffice\.gov\.uk,?\s*)+\z/,
+      /\A([a-z.\-\']+@digital\.cabinet-office\.gov\.uk,?\s*)+\z/,
+      /\A([a-z.\-\']+@cabinetoffice\.gov\.uk,?\s*)+\z/,
+      /\A([a-z.\-\']+@softwire\.com,?\s*)+\z/,
     )
   end
 

--- a/app/models/administrators_form.rb
+++ b/app/models/administrators_form.rb
@@ -4,7 +4,7 @@ class AdministratorsForm
   attr_reader :admin_users
   validates_format_of :admin_users,
                       with: EmailValidator.allowed_emails_regexp,
-                      message: 'should be a list of GDS emails'
+                      message: 'should be a list of approved emails'
   validates_each :admin_users do |record, attr, value|
     record.errors.add attr, 'is required' if value.nil? || value.empty?
   end

--- a/app/models/user_form.rb
+++ b/app/models/user_form.rb
@@ -4,7 +4,7 @@ class UserForm
   attr_reader :email_list
   validates_format_of :email_list,
                       with: EmailValidator.allowed_emails_regexp,
-                      message: 'should be a list of GDS emails'
+                      message: 'should be a list of approved emails'
   validates_each :email_list do |record, attr, value|
     record.errors.add attr, 'is required' if value.nil? || value == ''
   end

--- a/app/views/administrators/administrators.html.erb
+++ b/app/views/administrators/administrators.html.erb
@@ -9,7 +9,7 @@
           <legend>
             <p>
               Your account will be created with an administrative role so it can be bootstrapped.
-              Please specify the GDS emails of the users who should initially be able to assume this role.
+              Please specify the emails of the users who should initially be able to assume this role.
             </p>
             <p>
               Separate entries by new lines.
@@ -23,4 +23,3 @@
     <% end %>
   </div>
 </div>
-

--- a/app/views/remove_user/remove_user.html.erb
+++ b/app/views/remove_user/remove_user.html.erb
@@ -9,7 +9,7 @@
     <%= form_for @form, url: remove_user_path, html: { novalidate: true } do |f| %>
       <fieldset class="govuk-fieldset">
         <div class="govuk-form-group <%= 'govuk-form-group--error' if @form.errors.include?(:email_list) %>">
-          <%= f.label :email_list, 'GDS email addresses', class: 'govuk-label' %>
+          <%= f.label :email_list, 'Email addresses', class: 'govuk-label' %>
           <%= error_message_on(f.object.errors, :email_list) %>
           <%= f.text_area :email_list, value: @form.email_list, required: true, class: "govuk-textarea #{@form.errors&.any? ? 'govuk-textarea--error' : ''}", rows: '6' %>
         </div>

--- a/app/views/user/user.html.erb
+++ b/app/views/user/user.html.erb
@@ -10,7 +10,7 @@
     <%= form_for @form, url: user_path, html: { novalidate: true } do |f| %>
       <fieldset class="govuk-fieldset">
         <div class="govuk-form-group <%= 'govuk-form-group--error' if @form.errors.include?(:email_list) %>">
-          <%= f.label :email_list, 'GDS email addresses', class: 'govuk-label' %>
+          <%= f.label :email_list, 'Email addresses', class: 'govuk-label' %>
           <%= error_message_on(f.object.errors, :email_list) %>
           <%= f.text_area :email_list, value: @form.email_list, required: true, class: "govuk-textarea #{@form.errors&.any? ? 'govuk-textarea--error' : ''}", rows: '6' %>
         </div>
@@ -19,4 +19,3 @@
     <% end %>
   </div>
 </div>
-

--- a/test/controllers/administrators_controller_test.rb
+++ b/test/controllers/administrators_controller_test.rb
@@ -11,7 +11,7 @@ class AdministratorsControllerTest < ActionDispatch::IntegrationTest
   test 'should validate form' do
     post administrators_url, params: { administrators_form: { } }
     assert_response :success
-    assert_select '.govuk-error-message', 'Error:Admin users should be a list of GDS emails'
+    assert_select '.govuk-error-message', 'Error:Admin users should be a list of approved emails'
   end
 
   [

--- a/test/controllers/remove_users_controller_test.rb
+++ b/test/controllers/remove_users_controller_test.rb
@@ -26,7 +26,7 @@ class RemoveUserControllerTest < ActionDispatch::IntegrationTest
   test 'should validate form' do
     post remove_user_url, params: { user_form: { email_list: 'test.user@example.com' } }
     assert_response :success
-    assert_select '.govuk-error-message', 'Error:Email list should be a list of GDS emails'
+    assert_select '.govuk-error-message', 'Error:Email list should be a list of approved emails'
   end
 
   [

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -24,7 +24,7 @@ class UserControllerTest < ActionDispatch::IntegrationTest
   test 'should validate form' do
     post user_url, params: { user_form: { email_list: 'test.user@example.com' } }
     assert_response :success
-    assert_select '.govuk-error-message', 'Error:Email list should be a list of GDS emails'
+    assert_select '.govuk-error-message', 'Error:Email list should be a list of approved emails'
   end
 
   [

--- a/test/lib/email_validator_test.rb
+++ b/test/lib/email_validator_test.rb
@@ -1,14 +1,24 @@
 require 'test_helper'
 
 class EmailValidatorTest < ActiveSupport::TestCase
-  test 'GDS email addresses are allowed' do
+  test 'GDS email addresses are allowed to sign in' do
     email = 'fname.lname@digital.cabinet-office.gov.uk'
     assert EmailValidator.email_is_allowed?(email)
   end
 
-  test 'Cabinet Office email addresses are allowed' do
+  test 'Cabinet Office email addresses are allowed to sign in' do
     email = 'fname.lname@cabinetoffice.gov.uk'
     assert EmailValidator.email_is_allowed?(email)
+  end
+
+  test 'Softwire email addresses are not allowed to sign in' do
+    email = 'fname.lname@softwire.com'
+    assert ! EmailValidator.email_is_allowed?(email)
+  end
+
+  test 'Other email addresses are not allowed to sign in' do
+    email = 'fname.lname@example.com'
+    assert ! EmailValidator.email_is_allowed?(email)
   end
 
   test 'GDS emails are matched by the allowed emails regexp' do
@@ -19,5 +29,15 @@ class EmailValidatorTest < ActiveSupport::TestCase
   test 'Cabinet Office emails are matched by the allowed emails regexp' do
     email = 'fname.lname@cabinetoffice.gov.uk'
     assert_match EmailValidator.allowed_emails_regexp, email
+  end
+
+  test 'Softwire emails are matched by the allowed emails regexp' do
+    email = 'fname.lname@softwire.com'
+    assert_match EmailValidator.allowed_emails_regexp, email
+  end
+
+  test 'Other email addresses should not match emails regexp' do
+    email = 'fname.lname@example.com'
+    assert_no_match EmailValidator.allowed_emails_regexp, email
   end
 end


### PR DESCRIPTION
Adds "softwire.com" as an allowed gds-users domain _but_ not as an allowed log in domain