### PR TITLE
Mixed email validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This is a rails app, with dependencies managed by bundler. To run the app locall
 
 ```
 bundle install
+npm install
 bundle exec rails server
 ```
 

--- a/app/lib/email_validator.rb
+++ b/app/lib/email_validator.rb
@@ -9,11 +9,11 @@ module EmailValidator
 
   # which domains are allowed to be requested for a gds-users account
   def self.allowed_emails_regexp
-    Regexp.union(
-      /\A([a-z.\-\']+@digital\.cabinet-office\.gov\.uk,?\s*)+\z/,
-      /\A([a-z.\-\']+@cabinetoffice\.gov\.uk,?\s*)+\z/,
-      /\A([a-z.\-\']+@softwire\.com,?\s*)+\z/,
-    )
+    /\A(#{Regexp.union(
+      /([a-z.\-\']+@digital\.cabinet-office\.gov\.uk,?\s*)/,
+      /([a-z.\-\']+@cabinetoffice\.gov\.uk,?\s*)/,
+      /([a-z.\-\']+@softwire\.com,?\s*)/,
+    )})+\z/
   end
 
 end

--- a/test/lib/email_validator_test.rb
+++ b/test/lib/email_validator_test.rb
@@ -36,6 +36,14 @@ class EmailValidatorTest < ActiveSupport::TestCase
     assert_match EmailValidator.allowed_emails_regexp, email
   end
 
+  test 'Mixed list of valid emails are matched by the allowed emails regexp' do
+    emails = [
+      'test.user@digital.cabinet-office.gov.uk',
+      'test.user@cabinetoffice.gov.uk',
+    ].join(",\n")
+    assert_match EmailValidator.allowed_emails_regexp, emails
+  end
+
   test 'Other email addresses should not match emails regexp' do
     email = 'fname.lname@example.com'
     assert_no_match EmailValidator.allowed_emails_regexp, email


### PR DESCRIPTION
## What

updates the email validation regex to work with a mix of the valid email domains.

## Why

we allow several email domains now but the validator was only allowing contiguous list of the same email domain.

Fixes #97 