### PR TITLE
Error if an email address is too long

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -8,10 +8,15 @@ class UserController < ApplicationController
                     .fetch('user_form', {})
                     .permit(:email_list).to_h
     @form = UserForm.new(form_params)
-    return render :user if @form.invalid?
 
     requester_email = session.fetch('email')
     email_list = @form.email_list
+    emails = email_list.split.flat_map { |x| x.split(',') }
+    if emails.any? { |email| email.length > 64 } then
+      @form.errors.add 'email_list', 'contains email address over 64 characters in length - see if you can get the user an alias'
+    end
+
+    return render :user if @form.invalid?
 
     pull_request_url = GithubService.new.create_new_user_pull_request(email_list, requester_email) || 'error-creating-pull-request'
 


### PR DESCRIPTION
We take the email addresses and ultimately set their IAM username to that, but
it will fail if the user has a long email address. Our current workaround is to
suggest the relevant IT team grants a shorter alias.

See UserName length constraint on https://docs.aws.amazon.com/IAM/latest/APIReference/API_User.html