### PR TITLE
Error if an email address is too long, take 2

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -8,24 +8,25 @@ class UserController < ApplicationController
                     .fetch('user_form', {})
                     .permit(:email_list).to_h
     @form = UserForm.new(form_params)
+    return render :user if @form.invalid?
 
     requester_email = session.fetch('email')
     email_list = @form.email_list
-    emails = email_list.split.flat_map { |x| x.split(',') }
-    if emails.any? { |email| email.length > 64 } then
+
+    begin
+      pull_request_url = GithubService.new.create_new_user_pull_request(email_list, requester_email) || 'error-creating-pull-request'
+
+      session['pull_request_url'] = pull_request_url
+
+      notify_service = NotifyService.new
+      notify_service.new_user_email_support(email_list, requester_email, pull_request_url)
+      notify_service.new_user_email_user(email_list, requester_email, pull_request_url)
+
+      redirect_to confirmation_user_path
+    rescue EmailTooLongError => e
       @form.errors.add 'email_list', 'contains email address over 64 characters in length - see if you can get the user an alias'
+      log_error 'Email provided was too long', e
+      return render :user
     end
-
-    return render :user if @form.invalid?
-
-    pull_request_url = GithubService.new.create_new_user_pull_request(email_list, requester_email) || 'error-creating-pull-request'
-
-    session['pull_request_url'] = pull_request_url
-
-    notify_service = NotifyService.new
-    notify_service.new_user_email_support(email_list, requester_email, pull_request_url)
-    notify_service.new_user_email_user(email_list, requester_email, pull_request_url)
-
-    redirect_to confirmation_user_path
   end
 end

--- a/app/lib/errors.rb
+++ b/app/lib/errors.rb
@@ -1,0 +1,2 @@
+class EmailTooLongError < StandardError
+end

--- a/app/services/terraform_users_service.rb
+++ b/app/services/terraform_users_service.rb
@@ -9,6 +9,9 @@ class TerraformUsersService
   def add_users email_list_string
     terraform = @users_terraform
     split_email_list(email_list_string).each do |email|
+      if email.length > 64 then
+        raise EmailTooLongError.new
+      end
       terraform = add_user terraform, email
     end
 

--- a/test/services/terraform_users_service_test.rb
+++ b/test/services/terraform_users_service_test.rb
@@ -91,6 +91,13 @@ class TerraformUsersServiceTest < ActiveSupport::TestCase
     }
   end
 
+  test 'Raises if an email is too long' do
+    terraform_users_service = TerraformUsersService.new(INITIAL_USERS_TERRAFORM, INITIAL_GROUPS_TERRAFORM)
+    assert_raises {
+      terraform_users_service.add_users 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab@digital.cabinet-office.gov.uk'
+    }
+  end
+
   test 'User resources are sorted' do
     terraform_users_service = TerraformUsersService.new(INITIAL_USERS_TERRAFORM, INITIAL_GROUPS_TERRAFORM)
     result = terraform_users_service.add_users 'test.aws-user@example.com'


### PR DESCRIPTION
The issue with the previous attempt was likely around our understanding of
`@form.invalid?`, but also I figured we should be checking for these issues in
a different way anyway.

See also #126 and #138