### PR TITLE
Try to fix password reset form

### DIFF
--- a/app/controllers/reset_password_controller.rb
+++ b/app/controllers/reset_password_controller.rb
@@ -1,12 +1,14 @@
+class PasswordResetForm
+  include ActiveModel::Model
+end
+
 class ResetPasswordController < ApplicationController
   def reset_password
-    @form = UserForm.new({})
+    @form = PasswordResetForm.new({})
   end
 
   def post
-    form_params = params
-                    .fetch('reset_form', {})
-    @form = UserForm.new(form_params)
+    @form = PasswordResetForm.new({})
 
     requester_name = session.fetch('name')
     requester_email = session.fetch('email')


### PR DESCRIPTION
We don't specify any fields but do use it to show errors etc.

We had been seeing this:

```
NoMethodError (undefined method `with_indifferent_access' for <ActionController::Parameters {} permitted: false>:ActionController::Parameters):
app/models/user_form.rb:14:in `initialize'
app/controllers/reset_password_controller.rb:9:in `new'
app/controllers/reset_password_controller.rb:9:in `post'
```

UserForm should probably not have been in use here.

Untested and probably not the best Ruby in the world.