### PR TITLE
Allow contractors to log in to request password resets

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Run the tests with:
 bundle exec rails test
 ```
 
-To sign in as a development user, visit <http://localhost:3000/dev-login>. If you want to test with real Google SSO, you can [create an application in the Google Cloud Console](https://console.developers.google.com/apis/credentials).
+To sign in as a development user, visit <http://localhost:3000/dev-login> (to try different email addresses, you can provide a `email` parameter). If you want to test with real Google SSO, you can [create an application in the Google Cloud Console](https://console.developers.google.com/apis/credentials).
 
 Deploying to PaaS
 -----------------

--- a/app/controllers/development_controller.rb
+++ b/app/controllers/development_controller.rb
@@ -3,7 +3,7 @@ class DevelopmentController < ApplicationController
 
   def dev_login
     session['name'] = 'Example Developer'
-    session['email'] = 'example-developer@digital.cabinet-office.gov.uk'
+    session['email'] = params.fetch('email', 'example-developer@digital.cabinet-office.gov.uk')
     redirect_to index_path
   end
 end

--- a/app/controllers/google_auth_controller.rb
+++ b/app/controllers/google_auth_controller.rb
@@ -4,7 +4,7 @@ class GoogleAuthController < ApplicationController
   def callback
     email = request.env['omniauth.auth']['info']['email']
 
-    if EmailValidator.email_is_allowed?(email)
+    if EmailValidator.email_is_allowed_basic?(email)
       session['email'] = email
       session['name'] = request.env['omniauth.auth']['info']['name']
 

--- a/app/lib/email_validator.rb
+++ b/app/lib/email_validator.rb
@@ -1,7 +1,16 @@
 module EmailValidator
 
   # which allowed domains can sign in to the request an account service
-  def self.email_is_allowed?(email)
+  def self.email_is_allowed_basic?(email)
+    return true if email.end_with? '@digital.cabinet-office.gov.uk'
+    return true if email.end_with? '@cabinetoffice.gov.uk'
+    return true if email.end_with? '@softwire.com'
+    return true if email.end_with? '@fidusinfosec.com'
+    false
+  end
+
+  # which allowed domains can request accounts, new users, remove users, etc.
+  def self.email_is_allowed_advanced?(email)
     return true if email.end_with? '@digital.cabinet-office.gov.uk'
     return true if email.end_with? '@cabinetoffice.gov.uk'
     false

--- a/app/views/index/index.html.erb
+++ b/app/views/index/index.html.erb
@@ -6,6 +6,7 @@
 
       <p>You can use this service to:</p>
       <ul class="govuk-list govuk-list--bullet">
+        <% if EmailValidator.email_is_allowed_advanced?(@email) %>
         <li>
           <a class="govuk-link" href="#manage-users">
             Manage user access to Amazon Web Services (AWS)
@@ -16,10 +17,18 @@
             Request access to cloud computing resources
           </a>
         </li>
+        <% else %>
+        <li>
+          <a class="govuk-link" href="#manage-users">
+            Reset your AWS user password
+          </a>
+        </li>
+        <% end %>
       </ul>
 
       <h2 class="govuk-heading-m" id="manage-users">Manage user access to Amazon Web Services (AWS)</h2>
 
+      <% if EmailValidator.email_is_allowed_advanced?(@email) %>
       <h3 class="govuk-heading-s">Grant AWS access to a user</h3>
       <p>GDS manages a number of AWS accounts. Users for these accounts are managed centrally by reliability engineering with a base GDS account: <em>gds-users</em>.</p>
       <p>For a user to access resources in AWS they should be added to the <em>gds-users</em> base account and permitted to assume a role in the target account.</p>
@@ -37,6 +46,7 @@
       <p>
         <a href="<%= remove_user_path %>" class="govuk-button govuk-button--warning" data-module="govuk-button">Request user removal</a>
       </p>
+      <% end %>
 
       <h3 class="govuk-heading-s">Reset your AWS user password</h3>
       <p>If you need to reset your AWS password, you can do that here as well.</p>
@@ -44,6 +54,7 @@
         <a href="<%= reset_password_path %>" class="govuk-button" data-module="govuk-button">Request password reset</a>
       </p>
 
+      <% if EmailValidator.email_is_allowed_advanced?(@email) %>
       <h2 class="govuk-heading-m" id="request-cloud">
         Request access to cloud computing resources
       </h2>
@@ -77,15 +88,16 @@
       <a href="<%= account_details_path %>" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
         Request an account
       </a>
+      <% end %>
     <% else %>
-      <p>You can use this service to:</p>
+      <p>Depending on your email domain, you can use this service to:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>Grant AWS access to a user (e.g. for new joiners)</li>
-        <li>Remove AWS access from a user (e.g. for leavers)</li>
-        <li>Reset your AWS user password</li>
-        <li>Request a new AWS account (e.g. for a new service or environment)</li>
+        <li>Reset your AWS user password (for all users)</li>
+        <li>Grant AWS access to a user (e.g. for new joiners - Cabinet Office staff only)</li>
+        <li>Remove AWS access from a user (e.g. for leavers - Cabinet Office staff only)</li>
+        <li>Request a new AWS account (e.g. for a new service or environment - Cabinet Office staff only)</li>
       </ul>
-      <p>First you need to sign in with your GDS Google account so we know who you are.</p>
+      <p>First you need to sign in with your GDS or CO Google account so we know who you are.</p>
       <%= form_tag('/auth/google_oauth2', method: 'post') do %>
         <button type="submit" class="govuk-button" data-module="govuk-button">
           Sign in

--- a/test/lib/email_validator_test.rb
+++ b/test/lib/email_validator_test.rb
@@ -3,27 +3,52 @@ require 'test_helper'
 class EmailValidatorTest < ActiveSupport::TestCase
   test 'GDS email addresses are allowed to sign in' do
     email = 'fname.lname@digital.cabinet-office.gov.uk'
-    assert EmailValidator.email_is_allowed?(email)
+    assert EmailValidator.email_is_allowed_basic?(email)
   end
 
   test 'Cabinet Office email addresses are allowed to sign in' do
     email = 'fname.lname@cabinetoffice.gov.uk'
-    assert EmailValidator.email_is_allowed?(email)
+    assert EmailValidator.email_is_allowed_basic?(email)
   end
 
-  test 'Softwire email addresses are not allowed to sign in' do
+  test 'Softwire email addresses are allowed to sign in' do
     email = 'fname.lname@softwire.com'
-    assert ! EmailValidator.email_is_allowed?(email)
+    assert EmailValidator.email_is_allowed_basic?(email)
   end
 
-  test 'Fidusinfosec email addresses are not allowed to sign in' do
+  test 'Fidusinfosec email addresses are allowed to sign in' do
     email = 'fname.lname@fidusinfosec.com'
-    assert ! EmailValidator.email_is_allowed?(email)
+    assert EmailValidator.email_is_allowed_basic?(email)
   end
 
   test 'Other email addresses are not allowed to sign in' do
     email = 'fname.lname@example.com'
-    assert ! EmailValidator.email_is_allowed?(email)
+    assert ! EmailValidator.email_is_allowed_basic?(email)
+  end
+
+  test 'GDS email addresses are allowed to manage users' do
+    email = 'fname.lname@digital.cabinet-office.gov.uk'
+    assert EmailValidator.email_is_allowed_advanced?(email)
+  end
+
+  test 'Cabinet Office email addresses are allowed to manage users' do
+    email = 'fname.lname@cabinetoffice.gov.uk'
+    assert EmailValidator.email_is_allowed_advanced?(email)
+  end
+
+  test 'Softwire email addresses are not allowed to manage users' do
+    email = 'fname.lname@softwire.com'
+    assert ! EmailValidator.email_is_allowed_advanced?(email)
+  end
+
+  test 'Fidusinfosec email addresses are not allowed to manage users' do
+    email = 'fname.lname@fidusinfosec.com'
+    assert ! EmailValidator.email_is_allowed_advanced?(email)
+  end
+
+  test 'Other email addresses are not allowed to manage users' do
+    email = 'fname.lname@example.com'
+    assert ! EmailValidator.email_is_allowed_advanced?(email)
   end
 
   test 'GDS emails are matched by the allowed emails regexp' do


### PR DESCRIPTION
We probably don't want them requesting accounts, adding or removing users,
etc., but they should be able to change their own passwords without having to
come all the way to us.