### PR TITLE
Fix some issues with error handling on the check your answers page

### DIFF
--- a/app/controllers/check_your_answers_controller.rb
+++ b/app/controllers/check_your_answers_controller.rb
@@ -5,7 +5,8 @@ class CheckYourAnswersController < ApplicationController
   end
 
   def post
-    @details_form = AccountDetailsForm.new(session.fetch('form', {}))
+    @form = AccountDetailsForm.new(session.fetch('form', {}))
+    @answers = session.fetch('form', {}).with_indifferent_access
 
     all_params = session['form']
 
@@ -38,13 +39,13 @@ class CheckYourAnswersController < ApplicationController
       notify_service.new_account_email_user email, account_name, pull_request_url
 
       redirect_to confirmation_account_path
-    rescue AccountAlreadyExistsError => e
+    rescue Errors::AccountAlreadyExistsError => e
       @form.errors.add 'account_name', "account #{e.message} already exists"
-      log_error 'Account already existed', e
+      Errors::log_error 'Account already existed', e
       return render :check_your_answers
     rescue StandardError => e
       @form.errors.add 'commit', 'unknown error when opening pull request or sending email'
-      log_error 'Failed to raise account creation PR or send email', e
+      Errors::log_error 'Failed to raise account creation PR or send email', e
       return render :check_your_answers
     end
   end

--- a/app/controllers/remove_user_controller.rb
+++ b/app/controllers/remove_user_controller.rb
@@ -23,13 +23,13 @@ class RemoveUserController < ApplicationController
       notify_service.remove_user_email_user(email_list, requester_email, pull_request_url)
 
       redirect_to confirmation_remove_user_path
-    rescue UserDoesntExistError => e
+    rescue Errors::UserDoesntExistError => e
       @form.errors.add 'email_list', "user #{e.message} does not exist"
-      log_error 'User did not exist', e
+      Errors::log_error 'User did not exist', e
       return render :remove_user
     rescue StandardError => e
       @form.errors.add 'email_list', 'unknown error when opening pull request or sending email'
-      log_error 'Failed to raise user removal PR or send email', e
+      Errors::log_error 'Failed to raise user removal PR or send email', e
       return render :remove_user
     end
   end

--- a/app/controllers/reset_password_controller.rb
+++ b/app/controllers/reset_password_controller.rb
@@ -23,13 +23,13 @@ class ResetPasswordController < ApplicationController
       notify_service.reset_password_email_user(requester_name, requester_email, pull_request_url)
 
       redirect_to confirmation_reset_password_path
-    rescue UserDoesntExistError => e
+    rescue Errors::UserDoesntExistError => e
       @form.errors.add 'commit', "user #{e.message} does not exist"
-      log_error 'User did not exist', e
+      Errors::log_error 'User did not exist', e
       return render :reset_password
     rescue StandardError => e
       @form.errors.add 'commit', 'unknown error when opening pull request or sending email'
-      log_error 'Failed to raise user password reset PR', e
+      Errors::log_error 'Failed to raise user password reset PR', e
       return render :reset_password
     end
   end

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -23,17 +23,17 @@ class UserController < ApplicationController
       notify_service.new_user_email_user(email_list, requester_email, pull_request_url)
 
       redirect_to confirmation_user_path
-    rescue EmailTooLongError => e
+    rescue Errors::EmailTooLongError => e
       @form.errors.add 'email_list', 'contains email address over 64 characters in length - see if you can get the user an alias'
-      log_error 'Email provided was too long', e
+      Errors::log_error 'Email provided was too long', e
       return render :user
-    rescue UserAlreadyExistsError => e
+    rescue Errors::UserAlreadyExistsError => e
       @form.errors.add 'email_list', "user #{e.message} already exists"
-      log_error 'User already existed', e
+      Errors::log_error 'User already existed', e
       return render :user
     rescue StandardError => e
       @form.errors.add 'email_list', 'unknown error when opening pull request or sending email'
-      log_error 'Failed to raise new user PR or send email', e
+      Errors::log_error 'Failed to raise new user PR or send email', e
       return render :user
     end
   end

--- a/app/lib/errors.rb
+++ b/app/lib/errors.rb
@@ -1,21 +1,23 @@
-class EmailTooLongError < StandardError
-end
+module Errors
+  class EmailTooLongError < StandardError
+  end
 
-class UserAlreadyExistsError < StandardError
-end
+  class UserAlreadyExistsError < StandardError
+  end
 
-class UserDoesntExistError < StandardError
-end
+  class UserDoesntExistError < StandardError
+  end
 
-class AccountAlreadyExistsError < StandardError
-end
+  class AccountAlreadyExistsError < StandardError
+  end
 
-def log_error(description, error = nil)
-  Rails.logger.error({
-    '@timestamp': Time.now.iso8601,
-    description: description,
-    message: error ? error.message : nil,
-    backtrace: error ? error.backtrace.join("\n") : nil
-  }.to_json)
-  nil
+  def self.log_error(description, error = nil)
+    Rails.logger.error({
+                         '@timestamp': Time.now.iso8601,
+                        description: description,
+                        message: error ? error.message : nil,
+                        backtrace: error ? error.backtrace.join("\n") : nil
+                       }.to_json)
+    nil
+  end
 end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -9,7 +9,7 @@ class GithubService
 
   def create_new_account_pull_request(account_name, account_description, programme, email, admin_users)
     unless @client
-      log_error 'No GITHUB_PERSONAL_ACCESS_TOKEN set. Skipping pull request.'
+      Errors::log_error 'No GITHUB_PERSONAL_ACCESS_TOKEN set. Skipping pull request.'
       return nil
     end
 
@@ -58,7 +58,7 @@ Once the account is created, the following users should be granted access to the
 
   def create_new_user_pull_request(email_list, requester_email)
     unless @client
-      log_error 'No GITHUB_PERSONAL_ACCESS_TOKEN set. Skipping pull request.'
+      Errors::log_error 'No GITHUB_PERSONAL_ACCESS_TOKEN set. Skipping pull request.'
       return nil
     end
 
@@ -121,7 +121,7 @@ Co-authored-by: #{name} <#{requester_email}>",
 
   def create_remove_user_pull_request(email_list, requester_email)
     unless @client
-      log_error 'No GITHUB_PERSONAL_ACCESS_TOKEN set. Skipping pull request.'
+      Errors::log_error 'No GITHUB_PERSONAL_ACCESS_TOKEN set. Skipping pull request.'
       return nil
     end
 
@@ -186,7 +186,7 @@ Co-authored-by: #{requester_name} <#{requester_email}>",
 
   def create_reset_user_email_pull_request(requester_name, requester_email)
     unless @client
-      log_error 'No GITHUB_PERSONAL_ACCESS_TOKEN set. Skipping pull request.'
+      Errors::log_error 'No GITHUB_PERSONAL_ACCESS_TOKEN set. Skipping pull request.'
       return nil
     end
 
@@ -237,7 +237,7 @@ Co-authored-by: #{requester_name} <#{requester_email}>",
     begin
       @client.create_ref repo, 'heads/' + branch_name, sha
     rescue Octokit::UnprocessableEntity => e
-      log_error "Failed to create branch #{branch_name}. Perhaps there's already a branch with that name?", e
+      Errors::log_error "Failed to create branch #{branch_name}. Perhaps there's already a branch with that name?", e
     end
   end
 

--- a/app/services/terraform_accounts_service.rb
+++ b/app/services/terraform_accounts_service.rb
@@ -11,7 +11,7 @@ class TerraformAccountsService
     resource_names = accounts.map {|u| u['aws_organizations_account'].keys }.flatten
 
     if resource_names.include? account_name
-      raise AccountAlreadyExistsError.new account_name
+      raise Errors::AccountAlreadyExistsError.new account_name
     end
 
     accounts.push('aws_organizations_account' => {

--- a/app/services/terraform_users_service.rb
+++ b/app/services/terraform_users_service.rb
@@ -10,7 +10,7 @@ class TerraformUsersService
     terraform = @users_terraform
     split_email_list(email_list_string).each do |email|
       if email.length > 64 then
-        raise EmailTooLongError.new
+        raise Errors::EmailTooLongError.new
       end
       terraform = add_user terraform, email
     end
@@ -66,7 +66,7 @@ class TerraformUsersService
     resource_names = users.map {|u| u['aws_iam_user'].keys }.flatten
 
     unless resource_names.include? resource_name
-      raise UserDoesntExistError.new email
+      raise Errors::UserDoesntExistError.new email
     end
   end
 
@@ -82,7 +82,7 @@ class TerraformUsersService
     resource_names = users.map {|u| u['aws_iam_user'].keys }.flatten
 
     if resource_names.include? resource_name
-      raise UserAlreadyExistsError.new email
+      raise Errors::UserAlreadyExistsError.new email
     end
 
     users.push('aws_iam_user' => {
@@ -102,7 +102,7 @@ class TerraformUsersService
     resource_names = users.map {|u| u['aws_iam_user'].keys }.flatten
 
     unless resource_names.include? resource_name
-      raise UserDoesntExistError.new email
+      raise Errors::UserDoesntExistError.new email
     end
 
     users.select! { |user| !user['aws_iam_user'].has_key? resource_name }

--- a/app/views/check_your_answers/check_your_answers.html.erb
+++ b/app/views/check_your_answers/check_your_answers.html.erb
@@ -3,7 +3,7 @@
     <a href="<%= administrators_path %>" class="govuk-back-link">Back</a>
 
     <h1 class="govuk-heading-l">Check your answers</h1>
-    <%= error_summary_for(@details_form&.errors, :account_form) %>
+    <%= error_summary_for(@form&.errors, :account_form) %>
 
     <table class="govuk-table">  
       <thead class="govuk-table__head">
@@ -16,7 +16,7 @@
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
           <td class="govuk-table__header">Account name</td>
-          <td class="govuk-table__cell"><%= error_message_on(@details_form&.errors, :account_name) %> <%= @answers[:account_name] %></td>
+          <td class="govuk-table__cell"><%= error_message_on(@form&.errors, :account_name) %> <%= @answers[:account_name] %></td>
           <td class="govuk-table__cell"><%= link_to 'Change', account_details_path, class: 'govuk-link' %></td>
         </tr>
         <tr class="govuk-table__row">

--- a/test/controllers/check_your_answers_controller_test.rb
+++ b/test/controllers/check_your_answers_controller_test.rb
@@ -60,6 +60,22 @@ class CheckYourAnswersControllerTest < ActionDispatch::IntegrationTest
     assert_equal "https://some-new-account-pull-request-url", read_from_session("pull_request_url")
   end
 
+  test 'should handle the case where there is missing session data' do
+    accounts_terraform_before = build_content_request({ resource: [] })
+    stub_create_account_github_api(
+      accounts_terraform_before,
+      "https://some-new-account-pull-request-url")
+
+    set_session(
+      'test@example.com',
+      'account_name' => 'some-name'
+    )
+
+    post check_your_answers_url
+
+    assert_response 200
+  end
+
   def stub_create_account_github_api(accounts_terraform, resulting_pull_request_url)
     stub_request(:get, "#{ACCOUNT_MANAGEMENT_GITHUB_API}/commits/master").
       to_return(status: 200, body: '{"sha":"somesha"}', headers: {'Content-Type' => 'application/json'})


### PR DESCRIPTION
Because Rails, there's inconsistencies with how loading things works
in different environments (autoloading vs eagerloading). I think this
was leading to problems with loading the errors.rb file, at least when
running the tests.

To address this, this commit moves the things in that file in to a
module named like Rails would expect from the filename. This should
mean that Rails finds the right file when attempting to autoload
things.

This commit also changes a few other things that seemed to error, and
adds a test for the case where there's insufficient session data when
the post request is made.