### PR TITLE
Ask for and store information relevant to Cyber

### DIFF
--- a/app/controllers/check_your_answers_controller.rb
+++ b/app/controllers/check_your_answers_controller.rb
@@ -17,12 +17,45 @@ class CheckYourAnswersController < ApplicationController
     email = session['email']
 
     begin
+      tags = {
+        'description' => account_description,
+        'programme' => programme_or_other,
+
+        'team-name' => all_params['team_name'],
+        'team-email-address' => all_params['team_email_address'],
+        'team-lead-name' => all_params['team_lead_name'],
+        'team-lead-phone-number' => all_params['team_lead_phone_number'],
+        'team-lead-role' => all_params['team_lead_role'],
+
+        'service-name' => all_params['service_name'],
+        'service-is-out-of-hours-support-provided' => all_params['service_is_out_of_hours_support_provided'],
+
+        'security-requested-alert-priority-level' => all_params['security_requested_alert_priority_level'],
+        'security-critical-resources-description' => all_params['security_critical_resources_description'],
+        'security-does-account-hold-pii' => all_params['security_does_account_hold_personally_identifiable_information'],
+        'security-does-account-hold-pci-data' => all_params['security_does_account_hold_pci_data']
+      }
+
+      if all_params['service_is_out_of_hours_support_provided'] == 'true'
+        tags.merge!(
+          {
+            'out-of-hours-support-contact-name' => all_params['out_of_hours_support_contact_name'],
+            'out-of-hours-support-phone-number' => all_params['out_of_hours_support_phone_number'],
+            'out-of-hours-support-pagerduty-link' => all_params['out_of_hours_support_pagerduty_link'],
+            'out-of-hours-support-email-address' => all_params['out_of_hours_support_email_address']
+          }
+        )
+      end
+
+      tags.compact!
+
       pull_request_url = GithubService.new.create_new_account_pull_request(
         account_name,
         account_description,
         programme_or_other,
         email,
-        admin_users
+        admin_users,
+        tags
       )
 
       session['pull_request_url'] = pull_request_url

--- a/app/controllers/out_of_hours_support_controller.rb
+++ b/app/controllers/out_of_hours_support_controller.rb
@@ -1,0 +1,24 @@
+class OutOfHoursSupportController < ApplicationController
+  def out_of_hours_support
+    @form = OutOfHoursSupportForm.new(session.fetch('form', {}))
+  end
+
+  def post
+    form_params = params.fetch(
+      'out_of_hours_support_form',
+      {}
+    ).permit(
+      :out_of_hours_support_contact_name,
+      :out_of_hours_support_phone_number,
+      :out_of_hours_support_pagerduty_link,
+      :out_of_hours_support_email_address
+    ).to_h
+
+    @form = OutOfHoursSupportForm.new(form_params)
+    return render :out_of_hours_support if @form.invalid?
+
+    session['form'] = session.fetch('form', {}).merge form_params
+
+    redirect_to security_path
+  end
+end

--- a/app/controllers/programme_controller.rb
+++ b/app/controllers/programme_controller.rb
@@ -13,6 +13,6 @@ class ProgrammeController < ApplicationController
     session_form[:programme_or_other] = @form.programme_or_other
     session['form'] = session_form
 
-    redirect_to administrators_path
+    redirect_to team_path
   end
 end

--- a/app/controllers/security_controller.rb
+++ b/app/controllers/security_controller.rb
@@ -1,0 +1,23 @@
+class SecurityController < ApplicationController
+  def security
+    @form = SecurityForm.new(session.fetch('form', {}))
+  end
+
+  def post
+    form_params = params.fetch(
+      'security_form',
+      {}
+    ).permit(
+      :security_requested_alert_priority_level,
+      :security_critical_resources_description,
+      :security_does_account_hold_pii,
+      :security_does_account_hold_pci_data
+    ).to_h
+    @form = SecurityForm.new(form_params)
+    return render :security if @form.invalid?
+
+    session['form'] = session.fetch('form', {}).merge form_params
+
+    redirect_to administrators_path
+  end
+end

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -1,0 +1,23 @@
+class ServiceController < ApplicationController
+  def service
+    @form = ServiceForm.new(session.fetch('form', {}))
+  end
+
+  def post
+    form_params = params.fetch(
+      'service_form',
+      {}
+    ).permit(
+      :service_name,
+      :service_is_out_of_hours_support_provided
+    ).to_h
+    @form = ServiceForm.new(form_params)
+    return render :service if @form.invalid?
+
+    session['form'] = session.fetch('form', {}).merge form_params
+
+    redirect_to @form.service_is_out_of_hours_support_provided ?
+      out_of_hours_support_path :
+      security_path
+  end
+end

--- a/app/controllers/team_controller.rb
+++ b/app/controllers/team_controller.rb
@@ -1,0 +1,25 @@
+class TeamController < ApplicationController
+  def team
+    @form = TeamForm.new(session.fetch('form', {}))
+  end
+
+  def post
+    form_params = params.fetch(
+      'team_form', {}
+    ).permit(
+      :team_name,
+      :team_email_address,
+      :team_lead_name,
+      :team_lead_email_address,
+      :team_lead_phone_number,
+      :team_lead_role
+    ).to_h
+
+    @form = TeamForm.new(form_params)
+    return render :team if @form.invalid?
+
+    session['form'] = session.fetch('form', {}).merge form_params
+
+    redirect_to service_path
+  end
+end

--- a/app/models/account_details_form.rb
+++ b/app/models/account_details_form.rb
@@ -2,12 +2,11 @@ class AccountDetailsForm
   include ActiveModel::Model
 
   attr_reader :account_name, :account_description
+
   validates_format_of :account_name, with: /\A([a-z]+-)*[a-z]+\z/, message: 'should be lower-case-separated-by-dashes'
   validates_format_of :account_name, with: /\A([a-z]+-){0,4}[a-z]+\z/, message: 'should not have more-than-five-groups-separated-by-dashes'
-  validates_each :account_name, :account_description do |record, attr, value|
-    record.errors.add attr, 'is required' if value.nil? || value == ''
-  end
 
+  validates :account_name, :account_description, presence: true, length: { maximum: 256 }
 
   def initialize(hash)
     params = hash.with_indifferent_access

--- a/app/models/out_of_hours_support_form.rb
+++ b/app/models/out_of_hours_support_form.rb
@@ -1,0 +1,25 @@
+class OutOfHoursSupportForm
+  include ActiveModel::Model
+
+  attr_reader :out_of_hours_support_contact_name,
+              :out_of_hours_support_phone_number,
+              :out_of_hours_support_pagerduty_link,
+              :out_of_hours_support_email_address
+
+  validates :out_of_hours_support_phone_number,
+            presence: true,
+            length: { maximum: 256 }
+
+  validates :out_of_hours_support_contact_name,
+            :out_of_hours_support_pagerduty_link,
+            :out_of_hours_support_email_address,
+            length: { maximum: 256 }
+
+  def initialize(hash)
+    params = hash.with_indifferent_access
+    @out_of_hours_support_contact_name = params[:out_of_hours_support_contact_name]
+    @out_of_hours_support_phone_number = params[:out_of_hours_support_phone_number]
+    @out_of_hours_support_pagerduty_link = params[:out_of_hours_support_pagerduty_link]
+    @out_of_hours_support_email_address = params[:out_of_hours_support_email_address]
+  end
+end

--- a/app/models/security_form.rb
+++ b/app/models/security_form.rb
@@ -1,0 +1,29 @@
+class SecurityForm
+  include ActiveModel::Model
+
+  attr_reader :security_requested_alert_priority_level,
+              :security_critical_resources_description,
+              :security_does_account_hold_pii,
+              :security_does_account_hold_pci_data
+
+  validates :security_requested_alert_priority_level,
+            presence: true,
+            inclusion: { in: %w[P1 P2 P3 P4] }
+
+  validates :security_critical_resources_description,
+            presence: true,
+            length: { maximum: 256 }
+
+  validates :security_does_account_hold_pii,
+            :security_does_account_hold_pci_data,
+            presence: true,
+            inclusion: { in: %w[yes no] }
+
+  def initialize(hash)
+    params = hash.with_indifferent_access
+    @security_requested_alert_priority_level = params[:security_requested_alert_priority_level]
+    @security_critical_resources_description = params[:security_critical_resources_description]
+    @security_does_account_hold_pii = params[:security_does_account_hold_pii]
+    @security_does_account_hold_pci_data = params[:security_does_account_hold_pci_data]
+  end
+end

--- a/app/models/service_form.rb
+++ b/app/models/service_form.rb
@@ -1,0 +1,14 @@
+class ServiceForm
+  include ActiveModel::Model
+
+  attr_reader :service_name, :service_is_out_of_hours_support_provided
+
+  validates :service_name, :service_is_out_of_hours_support_provided,
+            presence: true, length: { maximum: 256 }
+
+  def initialize(hash)
+    params = hash.with_indifferent_access
+    @service_name = params[:service_name]
+    @service_is_out_of_hours_support_provided = params[:service_is_out_of_hours_support_provided]
+  end
+end

--- a/app/models/team_form.rb
+++ b/app/models/team_form.rb
@@ -1,0 +1,33 @@
+class TeamForm
+  include ActiveModel::Model
+
+  attr_reader :team_name, :team_email_address, :team_lead_name,
+              :team_lead_email_address, :team_lead_phone_number,
+              :team_lead_role
+
+  validates :team_name, :team_email_address, :team_lead_name,
+            :team_lead_role, presence: true, length: { maximum: 256 }
+
+  validate :at_least_one_contact_detail_provided?
+
+  def at_least_one_contact_detail_provided?
+    contact_fields = %w(
+      team_lead_email_address
+      team_lead_phone_number
+    )
+
+    if contact_fields.all? { |attr| send(attr).blank? }
+      errors.add :base, "A team lead email address or phone number must be provided"
+    end
+  end
+
+  def initialize(hash)
+    params = hash.with_indifferent_access
+    @team_name = params[:team_name]
+    @team_email_address = params[:team_email_address]
+    @team_lead_name = params[:team_lead_name]
+    @team_lead_email_address = params[:team_lead_email_address]
+    @team_lead_phone_number = params[:team_lead_phone_number]
+    @team_lead_role = params[:team_lead_role]
+  end
+end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -34,16 +34,16 @@ Description:
 #{account_description_quote}
 
 Co-authored-by: #{name} <#{email}>",
-    accounts_contents.sha,
-    new_account_terraform,
-    branch: new_branch_name
-  )
-  @client.create_pull_request(
-    github_repo,
-    'master',
-    new_branch_name,
-    "Add new AWS account for #{programme}: #{account_name}",
-    "Account requested using gds-request-an-aws-account.cloudapps.digital by #{email}
+      accounts_contents.sha,
+      new_account_terraform,
+      branch: new_branch_name
+    )
+    @client.create_pull_request(
+      github_repo,
+      'master',
+      new_branch_name,
+      "Add new AWS account for #{programme}: #{account_name}",
+      "Account requested using gds-request-an-aws-account.cloudapps.digital by #{email}
 
 Description:
 #{account_description_quote}

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -7,7 +7,7 @@ class GithubService
     end
   end
 
-  def create_new_account_pull_request(account_name, account_description, programme, email, admin_users)
+  def create_new_account_pull_request(account_name, account_description, programme, email, admin_users, tags)
     unless @client
       Errors::log_error 'No GITHUB_PERSONAL_ACCESS_TOKEN set. Skipping pull request.'
       return nil
@@ -23,7 +23,7 @@ class GithubService
 
     name = email.split('@').first.split('.').map { |name| name.capitalize }.join(' ')
     terraform_accounts_service = TerraformAccountsService.new(Base64.decode64(accounts_contents.content))
-    new_account_terraform = terraform_accounts_service.add_account(account_name)
+    new_account_terraform = terraform_accounts_service.add_account(account_name, tags)
     account_description_quote = account_description.split(/\r?\n/).map {|desc| "> #{desc}"}.join("\n")
     @client.update_contents(
       github_repo,

--- a/app/services/terraform_accounts_service.rb
+++ b/app/services/terraform_accounts_service.rb
@@ -6,7 +6,7 @@ class TerraformAccountsService
     @users_terraform = JSON.parse users_terraform
   end
 
-  def add_account(account_name)
+  def add_account(account_name, tags)
     accounts = @users_terraform.fetch 'resource'
     resource_names = accounts.map {|u| u['aws_organizations_account'].keys }.flatten
 
@@ -20,6 +20,7 @@ class TerraformAccountsService
         'email': AWS_ROOT_ACCOUNTS_EMAIL_FORMAT % truncate_account_name_for_email(account_name),
         'role_name': 'bootstrap',
         'iam_user_access_to_billing': 'ALLOW',
+        'tags': tags,
         'lifecycle': {
           'ignore_changes': [
             'tags'

--- a/app/views/check_your_answers/check_your_answers.html.erb
+++ b/app/views/check_your_answers/check_your_answers.html.erb
@@ -34,6 +34,83 @@
           <td class="govuk-table__cell"><%= @answers[:admin_users] %></td>
           <td class="govuk-table__cell"><%= link_to 'Change', administrators_path, class: 'govuk-link' %></td>
         </tr>
+
+        <tr class="govuk-table__row">
+          <td colspan="3"
+              class="govuk-table__header govuk-!-font-size-24"
+              style="padding-top: 1.3em;">
+            Team</td>
+        </tr>
+        <% [["Team name", :team_name],
+            ["Team email address", :team_email_address],
+            ["Team lead name", :team_lead_name],
+            ["Team lead email address", :team_lead_email_address],
+            ["Team lead phone number", :team_lead_phone_number],
+            ["Team lead role", :team_lead_role]].each do |(label, field)|
+        %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__header"><%= label %></td>
+            <td class="govuk-table__cell"><%= @answers[field] %></td>
+            <td class="govuk-table__cell"><%= link_to 'Change', team_path, class: 'govuk-link' %></td>
+          </tr>
+        <% end %>
+
+        <tr class="govuk-table__row">
+          <td colspan="3"
+              class="govuk-table__header govuk-!-font-size-24"
+              style="padding-top: 1.3em;">
+            Service</td>
+        </tr>
+        <% [["Service name", :service_name],
+            ["Service: Is out of hours support provided?",
+             :service_is_out_of_hours_support_provided]].each do |(label, field)|
+        %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__header"><%= label %></td>
+            <td class="govuk-table__cell"><%= @answers[field] %></td>
+            <td class="govuk-table__cell"><%= link_to 'Change', service_path, class: 'govuk-link' %></td>
+          </tr>
+        <% end %>
+
+        <% if @answers[:service_is_out_of_hours_support_provided] == "true" %>
+          <tr class="govuk-table__row">
+            <td colspan="3"
+                class="govuk-table__header govuk-!-font-size-24"
+                style="padding-top: 1.3em;">
+              Out of hours support</td>
+          </tr>
+          <% [["Out of hours support contact name", :out_of_hours_support_contact_name],
+              ["Out of hours support phone number", :out_of_hours_support_phone_number],
+              ["Out of hours support PagerDuty link", :out_of_hours_support_pagerduty_link],
+              ["Out of hours support email address", :out_of_hours_support_email_addres]].each do |(label, field)|
+          %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__header"><%= label %></td>
+              <td class="govuk-table__cell"><%= @answers[field] %></td>
+              <td class="govuk-table__cell"><%= link_to 'Change', out_of_hours_support_path, class: 'govuk-link' %></td>
+            </tr>
+          <% end %>
+        <% end %>
+
+        <tr class="govuk-table__row">
+          <td colspan="3"
+              class="govuk-table__header govuk-!-font-size-24"
+              style="padding-top: 1.3em;">
+            Security</td>
+        </tr>
+        <% [["Security requested alert priority level", :security_requested_alert_priority_level],
+            ["Security critical resources description", :security_critical_resources_description],
+            ["Security: does account hold Personally Identifiable Information?",
+             :security_does_account_hold_pii],
+            ["Security: does account hold Payment Card Industry data? ",
+             :security_does_account_hold_pci_dat]].each do |(label, field)|
+        %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__header"><%= label %></td>
+            <td class="govuk-table__cell"><%= @answers[field] %></td>
+            <td class="govuk-table__cell"><%= link_to 'Change', security_path, class: 'govuk-link' %></td>
+          </tr>
+        <% end %>
       </tbody>
     </table>
 

--- a/app/views/out_of_hours_support/out_of_hours_support.html.erb
+++ b/app/views/out_of_hours_support/out_of_hours_support.html.erb
@@ -1,0 +1,67 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <a href="<%= index_path %>" class="govuk-back-link">Back</a>
+    <h1 class="govuk-heading-l">Out of hours support details</h1>
+    <%= error_summary_for(@form&.errors, :out_of_hours_support_form) %>
+    <%= form_for @form, url: out_of_hours_support_path, html: { novalidate: true } do |f| %>
+      <fieldset class="govuk-fieldset">
+        <div class="govuk-form-group <%= 'govuk-form-group--error' if @form.errors.include?(:out_of_hours_support_contact_name) %>">
+          <%= f.label(
+            :out_of_hours_support_contact_name,
+            'Responsible person or group (optional)',
+            class: 'govuk-label govuk-label--m'
+          ) %>
+          <span class="govuk-hint">
+            This could be an individual, or the name of a group. Leave
+            blank if this isn't applicable.
+          </span>
+          <%= error_message_on(f.object.errors, :out_of_hours_support_contact_name) %>
+          <%= f.text_field(
+            :out_of_hours_support_contact_name,
+            value: @form.out_of_hours_support_contact_name,
+            class: "govuk-input govuk-input--width-20"
+          ) %>
+        </div>
+      </fieldset>
+      <fieldset class="govuk-fieldset">
+        <%= f.label(
+          :out_of_hours_support_email_address,
+          'Contact details',
+          class: 'govuk-label govuk-label--m'
+        ) %>
+        <div class="govuk-form-group <%= 'govuk-form-group--error' if @form.errors.include?(:out_of_hours_support_phone_number) %>">
+          <%= f.label :out_of_hours_support_phone_number, 'Phone number', class: 'govuk-label' %>
+          <%= error_message_on(f.object.errors, :out_of_hours_support_phone_number) %>
+          <%= f.text_field(
+            :out_of_hours_support_phone_number, value: @form.out_of_hours_support_phone_number,
+            required: true,
+            class: "govuk-input govuk-input--width-20 #{@form.errors.include?(:out_of_hours_support_phone_number) ? 'govuk-input--error' : ''}",
+            type: "tel",
+            autocomplete: "tel"
+          ) %>
+        </div>
+        <div class="govuk-form-group">
+          <%= f.label :out_of_hours_support_pagerduty_link, 'PagerDuty link', class: 'govuk-label' %>
+          <%= error_message_on(f.object.errors, :out_of_hours_support_pagerduty_link) %>
+          <%= f.text_field(
+            :out_of_hours_support_pagerduty_link, value: @form.out_of_hours_support_pagerduty_link,
+            class: "govuk-input govuk-input--width-20"
+          ) %>
+        </div>
+        <div class="govuk-form-group">
+          <%= f.label :out_of_hours_support_email_address, 'Email address', class: 'govuk-label' %>
+          <span class="govuk-hint">
+            This may be a shared inbox or mailing list.
+          </span>
+          <%= error_message_on(f.object.errors, :out_of_hours_support_email_address) %>
+          <%= f.text_field(
+            :out_of_hours_support_email_address, value: @form.out_of_hours_support_email_address,
+            class: "govuk-input govuk-input--width-20"
+          ) %>
+        </div>
+      </fieldset>
+
+      <%= f.submit 'Next', class: 'govuk-button', data: { module: "govuk-button" } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/security/security.html.erb
+++ b/app/views/security/security.html.erb
@@ -1,0 +1,121 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <a href="<%= index_path %>" class="govuk-back-link">Back</a>
+    <h1 class="govuk-heading-l">Security</h1>
+    <%= error_summary_for(@form&.errors, :out_of_hours_support_form) %>
+    <%= form_for @form, url: security_path, html: { novalidate: true } do |f| %>
+      <fieldset class="govuk-fieldset">
+        <div class="govuk-form-group <%= 'govuk-form-group--error' if @form.errors.include?(:security_requested_alert_priority_level) %>">
+          <%= f.label :security_requested_alert_priority_level, 'Requested alert priority level', class: 'govuk-label govuk-label--m' %>
+          <span class="govuk-hint">
+            For the use of the Cyber team to prioritise handling
+            security issues for this specific account.
+          </span>
+          <%= error_message_on(f.object.errors, :security_requested_alert_priority_level) %>
+          <div class="govuk-radios">
+            <% [["P1", "Production account, or those with specific security concerns"],
+                ["P2", "Staging account with some important production data"],
+                ["P3", "Staging account with no sensitive data"],
+                ["P4", "Demo account, no sensitive data or infrastructure"]].each do |(priority, help)| %>
+            <div class="govuk-radios__item">
+              <%= f.radio_button(
+                :security_requested_alert_priority_level,
+                priority,
+                class: "govuk-radios__input"
+              ) %>
+              <%= f.label(
+                "security_requested_alert_priority_level_#{priority}".to_sym,
+                priority,
+                class: 'govuk-label govuk-radios__label'
+              ) %>
+              <span style="display: inline-block;" class="govuk-hint"><%= help %></span>
+            </div>
+            <% end %>
+          </div>
+        </div>
+      </fieldset>
+      <fieldset class="govuk-fieldset">
+        <div class="govuk-form-group <%= 'govuk-form-group--error' if @form.errors.include?(:security_critical_resources_description) %>">
+          <%= f.label :security_critical_resources_description, 'What are the most critical resources?', class: 'govuk-label govuk-label--m' %>
+          <span class="govuk-hint">
+            From a security perspective, that will reside in this
+            account.
+          </span>
+          <%= error_message_on(f.object.errors, :security_critical_resources_description) %>
+          <%= f.text_field(
+            :security_critical_resources_description,
+            value: @form.security_critical_resources_description,
+            required: true,
+            class: "govuk-input govuk-input--width-20 #{@form.errors&.any? ? 'govuk-textarea--error' : ''}"
+          ) %>
+        </div>
+      </fieldset>
+      <fieldset class="govuk-fieldset">
+        <div class="govuk-form-group <%= 'govuk-form-group--error' if @form.errors.include?(:security_does_account_hold_pii) %>">
+          <%= f.label :security_does_account_hold_pii, 'Does the account hold Personally Identifiable Information (PII)?', class: 'govuk-label govuk-label--m' %>
+          <%= error_message_on(f.object.errors, :security_does_account_hold_pii) %>
+          <div class="govuk-radios govuk-radios--inline">
+            <div class="govuk-radios__item">
+              <%= f.radio_button(
+                :security_does_account_hold_pii,
+                "yes",
+                class: "govuk-radios__input"
+              ) %>
+              <%= f.label(
+                "security_requested_alert_priority_level_yes".to_sym,
+                "Yes",
+                class: 'govuk-label govuk-radios__label'
+              ) %>
+            </div>
+            <div class="govuk-radios__item">
+              <%= f.radio_button(
+                :security_does_account_hold_pii,
+                "no",
+                class: "govuk-radios__input"
+              ) %>
+              <%= f.label(
+                "security_requested_alert_priority_level_no".to_sym,
+                "No",
+                class: 'govuk-label govuk-radios__label'
+              ) %>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+      <fieldset class="govuk-fieldset">
+        <div class="govuk-form-group <%= 'govuk-form-group--error' if @form.errors.include?(:security_does_account_hold_pci_data) %>">
+          <%= f.label :security_does_account_hold_pci_data, 'Does the account hold Payment Card Industry data?', class: 'govuk-label govuk-label--m' %>
+          <%= error_message_on(f.object.errors, :security_does_account_hold_pci_data) %>
+          <div class="govuk-radios govuk-radios--inline">
+            <div class="govuk-radios__item">
+              <%= f.radio_button(
+                :security_does_account_hold_pci_data,
+                "yes",
+                class: "govuk-radios__input"
+              ) %>
+              <%= f.label(
+                "security_requested_alert_priority_level_yes".to_sym,
+                "Yes",
+                class: 'govuk-label govuk-radios__label'
+              ) %>
+            </div>
+            <div class="govuk-radios__item">
+              <%= f.radio_button(
+                :security_does_account_hold_pci_data,
+                "no",
+                class: "govuk-radios__input"
+              ) %>
+              <%= f.label(
+                "security_requested_alert_priority_level_no".to_sym,
+                "No",
+                class: 'govuk-label govuk-radios__label'
+              ) %>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+
+      <%= f.submit 'Next', class: 'govuk-button', data: { module: "govuk-button" } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/service/service.html.erb
+++ b/app/views/service/service.html.erb
@@ -1,0 +1,68 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <a href="<%= index_path %>" class="govuk-back-link">Back</a>
+    <h1 class="govuk-heading-l">Service details</h1>
+    <%= error_summary_for(@form&.errors, :service_form) %>
+    <%= form_for @form, url: service_path, html: { novalidate: true } do |f| %>
+      <fieldset class="govuk-fieldset">
+        <div class="govuk-form-group <%= 'govuk-form-group--error' if @form.errors.include?(:service_name) %>">
+          <%= f.label :service_name, 'Service name', class: 'govuk-label govuk-label--m' %>
+          <span class="govuk-hint">
+            This is like GOV.UK, or EIDAS (in the context of verify)
+          </span>
+          <%= error_message_on(f.object.errors, :service_name) %>
+          <%= f.text_field(
+            :service_name,
+            value: @form.service_name,
+            required: true,
+            class: "govuk-input govuk-input--width-20 #{@form.errors&.any? ? 'govuk-textarea--error' : ''}"
+          ) %>
+        </div>
+      </fieldset>
+      <fieldset class="govuk-fieldset">
+        <div class="govuk-form-group <%= 'govuk-form-group--error' if @form.errors.include?(:service_is_out_of_hours_support_provided) %>">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+            <h1 class="govuk-fieldset__heading">
+              Is out of hours support provided?
+            </h1>
+          </legend>
+          <span class="govuk-hint">
+            Select yes if there is a group or individual which would
+            respond to issues relating to this account, out of normal
+            working hours.
+          </span>
+          <%= error_message_on(f.object.errors, :service_is_out_of_hours_support_provided) %>
+
+          <div class="govuk-radios govuk-radios--inline">
+            <div class="govuk-radios__item">
+              <%= f.radio_button(
+                :service_is_out_of_hours_support_provided,
+                true,
+                class: "govuk-radios__input"
+              ) %>
+              <%= f.label(
+                :service_is_out_of_hours_support_provided_true,
+                'Yes',
+                class: 'govuk-label govuk-radios__label'
+              ) %>
+            </div>
+            <div class="govuk-radios__item">
+              <%= f.radio_button(
+                :service_is_out_of_hours_support_provided,
+                false,
+                class: "govuk-radios__input"
+              ) %>
+              <%= f.label(
+                :service_is_out_of_hours_support_provided_false,
+                'No',
+                class: 'govuk-label govuk-radios__label'
+              ) %>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+
+      <%= f.submit 'Next', class: 'govuk-button', data: { module: "govuk-button" } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/team/team.html.erb
+++ b/app/views/team/team.html.erb
@@ -1,0 +1,96 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <a href="<%= index_path %>" class="govuk-back-link">Back</a>
+    <h1 class="govuk-heading-l">Team details</h1>
+    <%= error_summary_for(@form&.errors, :team_form) %>
+    <%= form_for @form, url: team_path, html: { novalidate: true } do |f| %>
+      <fieldset class="govuk-fieldset">
+        <div class="govuk-form-group <%= 'govuk-form-group--error' if @form.errors.include?(:team_name) %>">
+          <%= f.label :team_name, 'Name', class: 'govuk-label govuk-label--m' %>
+          <span class="govuk-hint">
+            This might be the same as your programme, responsible
+            business unit or service team.
+          </span>
+          <%= error_message_on(f.object.errors, :team_name) %>
+          <%= f.text_field(
+            :team_name,
+            value: @form.team_name,
+            required: true,
+            class: "govuk-input govuk-input--width-20 #{@form.errors.include?(:team_name) ? 'govuk-input--error' : ''}"
+          ) %>
+        </div>
+      </fieldset>
+      <fieldset class="govuk-fieldset">
+        <div class="govuk-form-group <%= 'govuk-form-group--error' if @form.errors.include?(:team_email_address) %>">
+          <%= f.label(
+            :team_email_address,
+            'Shared email address',
+            class: 'govuk-label govuk-label--m'
+          ) %>
+          <span class="govuk-hint">
+            Please provide the email address for a shared inbox or
+            mailing list that the team can be contacted using.
+          </span>
+          <%= error_message_on(f.object.errors, :team_email_address) %>
+          <%= f.text_field(
+            :team_email_address, value: @form.team_email_address,
+            required: true,
+            class: "govuk-input govuk-input--width-20 #{@form.errors.include?(:team_email_address) ? 'govuk-input--error' : ''}"
+          ) %>
+        </div>
+      </fieldset>
+      <fieldset class="govuk-fieldset">
+        <%= f.label(
+          :team_email_address,
+          'Team lead',
+          class: 'govuk-label govuk-label--m'
+        ) %>
+        <div class="govuk-form-group <%= 'govuk-form-group--error' if @form.errors.include?(:team_lead_name) %>">
+          <%= f.label :team_lead_name, 'Name', class: 'govuk-label' %>
+          <%= error_message_on(f.object.errors, :team_lead_name) %>
+          <%= f.text_field(
+            :team_lead_name,
+            value: @form.team_lead_name,
+            required: true,
+            class: "govuk-input govuk-input--width-20 #{@form.errors.include?(:team_lead_name) ? 'govuk-input--error' : ''}"
+          ) %>
+        </div>
+        <div class="govuk-form-group <%= 'govuk-form-group--error' if @form.errors.include?(:team_lead_role) %>">
+          <%= f.label :team_lead_role, 'Role', class: 'govuk-label' %>
+          <%= error_message_on(f.object.errors, :team_lead_role) %>
+          <%= f.text_field(
+            :team_lead_role, value: @form.team_lead_role,
+            required: true,
+            class: "govuk-input govuk-input--width-20 #{@form.errors.include?(:team_lead_role) ? 'govuk-input--error' : ''}"
+          ) %>
+        </div>
+        <div class="govuk-form-group <%= 'govuk-form-group--error' if @form.errors.include?(:team_lead_email_address) %>">
+          <%= f.label :team_lead_email_address, 'Email address', class: 'govuk-label' %>
+          <%= error_message_on(f.object.errors, :team_lead_email_address) %>
+          <span class="govuk-hint">
+            Shared inbox prefered
+          </span>
+          <%= f.text_field(
+            :team_lead_email_address,
+            value: @form.team_lead_email_address,
+            spellcheck: "false",
+            autocomplete: "email",
+            class: "govuk-input govuk-input--width-20 #{@form.errors.include?(:team_lead_email_address) ? 'govuk-input--error' : ''}"
+          ) %>
+        </div>
+        <div class="govuk-form-group <%= 'govuk-form-group--error' if @form.errors.include?(:team_lead_phone_number) %>">
+          <%= f.label :team_phone_number, 'Phone number', class: 'govuk-label' %>
+          <%= error_message_on(f.object.errors, :team_lead_phone_number) %>
+          <%= f.text_field(
+            :team_lead_phone_number, value: @form.team_lead_phone_number,
+            type: "tel",
+            autocomplete: "tel",
+            class: "govuk-input govuk-input--width-20 #{@form.errors.include?(:team_lead_phone_number) ? 'govuk-input--error' : ''}"
+          ) %>
+        </div>
+      </fieldset>
+
+      <%= f.submit 'Next', class: 'govuk-button', data: { module: "govuk-button" } %>
+    <% end %>
+  </div>
+</div>

--- a/config/initializers/action_view.rb
+++ b/config/initializers/action_view.rb
@@ -1,0 +1,3 @@
+ActionView::Base.field_error_proc = Proc.new do |html_tag, instance|
+  html_tag.html_safe
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,18 @@ Rails.application.routes.draw do
   get '/programme', to: 'programme#programme', as: :programme
   post '/programme', to: 'programme#post'
 
+  get '/team', to: 'team#team', as: :team
+  post '/team', to: 'team#post'
+
+  get '/service', to: 'service#service', as: :service
+  post '/service', to: 'service#post'
+
+  get '/out-of-hours-support', to: 'out_of_hours_support#out_of_hours_support', as: :out_of_hours_support
+  post '/out-of-hours-support', to: 'out_of_hours_support#post'
+
+  get '/security', to: 'security#security', as: :security
+  post '/security', to: 'security#post'
+
   get '/administrators', to: 'administrators#administrators', as: :administrators
   post '/administrators', to: 'administrators#post'
 

--- a/test/controllers/check_your_answers_controller_test.rb
+++ b/test/controllers/check_your_answers_controller_test.rb
@@ -13,6 +13,25 @@ class CheckYourAnswersControllerTest < ActionDispatch::IntegrationTest
       'account_name' => 'some-name',
       'programme' => 'GOV.UK',
       'account_description' => 'some account description',
+
+      'team_name' => 'Platform Health',
+      'team_email_address' => 'foo@example.com',
+      'team_lead_name' => 'Team Lead',
+      'team_lead_phone_number' => '00000000000',
+      'team_lead_role' => 'Developer',
+
+      'service_name' => 'GOV.UK',
+      'service_is_out_of_hours_support_provided' => 'true',
+
+      'out_of_hours_support_contact_name' => 'Support Contact',
+      'out_of_hours_support_phone_number' => '000000000000',
+      'out_of_hours_support_pagerduty_link' => 'https://pagerduty.example.com',
+      'out_of_hours_support_email_address' => 'outofhours@example.com',
+
+      'security_requested_alert_priority_level' => 'P1',
+      'security_critical_resources_description' => 'User data stored in blah S3 bucket',
+      'security_does_account_hold_personally_identifiable_information' => 'true',
+      'security_does_account_hold_pci_data' => 'false'
     )
   }
 
@@ -43,6 +62,24 @@ class CheckYourAnswersControllerTest < ActionDispatch::IntegrationTest
           "email" => "aws-root-accounts+some-name@digital.cabinet-office.gov.uk",
           "role_name" => "bootstrap",
           "iam_user_access_to_billing" => "ALLOW",
+          "tags" => {
+            "description" => "some account description",
+            "team-name" => "Platform Health",
+            "team-email-address" => "foo@example.com",
+            "team-lead-name" => "Team Lead",
+            "team-lead-phone-number" => "00000000000",
+            "team-lead-role" => "Developer",
+            "service-name" => "GOV.UK",
+            "service-is-out-of-hours-support-provided" => "true",
+            "security-requested-alert-priority-level" => "P1",
+            "security-critical-resources-description" => "User data stored in blah S3 bucket",
+            "security-does-account-hold-pii" => "true",
+            "security-does-account-hold-pci-data" => "false",
+            "out-of-hours-support-contact-name" => "Support Contact",
+            "out-of-hours-support-phone-number" => "000000000000",
+            "out-of-hours-support-pagerduty-link" => "https://pagerduty.example.com",
+            "out-of-hours-support-email-address" => "outofhours@example.com"
+          },
           "lifecycle" => { "ignore_changes" => ["tags"]}
         }
       },

--- a/test/controllers/programme_controller_test.rb
+++ b/test/controllers/programme_controller_test.rb
@@ -22,16 +22,16 @@ class ProgrammeControllerTest < ActionDispatch::IntegrationTest
 
   test 'should redirect on valid form with programme' do
     post programme_url, params: { programme_form: { programme: 'GOV.UK' } }
-    assert_redirected_to administrators_url
+    assert_redirected_to team_url
   end
 
   test 'should redirect on valid form with other programme' do
     post programme_url, params: { programme_form: { programme: 'Other', programme_other: 'Brexit' } }
-    assert_redirected_to administrators_url
+    assert_redirected_to team_url
   end
 
   test 'should redirect on valid form with nil programme but other set' do
     post programme_url, params: { programme_form: { programme: nil, programme_other: 'Brexit' } }
-    assert_redirected_to administrators_url
+    assert_redirected_to team_url
   end
 end

--- a/test/services/terraform_accounts_service_test.rb
+++ b/test/services/terraform_accounts_service_test.rb
@@ -32,7 +32,13 @@ EOTERRAFORM
 class TerraformAccountsServiceTest < ActiveSupport::TestCase
   test 'Adds an account' do
     terraform_accounts_service = TerraformAccountsService.new(INITIAL_ACCOUNTS_TERRAFORM)
-    result = terraform_accounts_service.add_account 'gds-wombles-of-wimbledon-test'
+    tags = {
+      'description' => 'Description.'
+    }
+    result = terraform_accounts_service.add_account(
+      'gds-wombles-of-wimbledon-test',
+      tags
+    )
 
     assert_match /"gds-wombles-of-wimbledon-test"/, result
     assert_match /"aws-root-accounts\+wom-of-wim-tes@digital\.cabinet-office\.gov\.uk"/, result


### PR DESCRIPTION
These changes add several new form screens to the process of requesting a new AWS account.

The information from these is output in to tags within the Terraform for creating the account, and from their should be accessible in Splunk.

![image](https://user-images.githubusercontent.com/1130010/125477169-b6a69c1c-f3a6-4772-b447-299d5d644b40.png)
![image](https://user-images.githubusercontent.com/1130010/125477232-ed12f697-1b0c-4594-9c43-6115d7c4ec4a.png)
![image](https://user-images.githubusercontent.com/1130010/125477287-b390e4dc-7a13-4220-963f-1caa5242fb1a.png)
![image](https://user-images.githubusercontent.com/1130010/125477339-d58667ea-babc-4113-9f90-29a1789c6a00.png)