### PR TITLE
Add a missing a

### DIFF
--- a/app/views/check_your_answers/check_your_answers.html.erb
+++ b/app/views/check_your_answers/check_your_answers.html.erb
@@ -103,7 +103,7 @@
             ["Security: does account hold Personally Identifiable Information?",
              :security_does_account_hold_pii],
             ["Security: does account hold Payment Card Industry data? ",
-             :security_does_account_hold_pci_dat]].each do |(label, field)|
+             :security_does_account_hold_pci_data]].each do |(label, field)|
         %>
           <tr class="govuk-table__row">
             <td class="govuk-table__header"><%= label %></td>


### PR DESCRIPTION
This fixes the "Security: does account hold Payment Card Industry
data?" field showing up on the check your answers page.