### PR TITLE
Add the account name as a tag to accounts

### DIFF
--- a/app/controllers/check_your_answers_controller.rb
+++ b/app/controllers/check_your_answers_controller.rb
@@ -19,6 +19,7 @@ class CheckYourAnswersController < ApplicationController
 
     begin
       tags = {
+        'account-name' => account_name,
         'description' => account_description,
         'organisation' => organisation_or_other,
         'programme' => programme_or_other,

--- a/test/controllers/check_your_answers_controller_test.rb
+++ b/test/controllers/check_your_answers_controller_test.rb
@@ -63,6 +63,7 @@ class CheckYourAnswersControllerTest < ActionDispatch::IntegrationTest
           "role_name" => "bootstrap",
           "iam_user_access_to_billing" => "ALLOW",
           "tags" => {
+            "account-name" => "some-name",
             "description" => "some account description",
             "team-name" => "Platform Health",
             "team-email-address" => "foo@example.com",


### PR DESCRIPTION
As this makes looking at the tags on accounts easier in Splunk.