### PR TITLE
account requests: restrict set of allowed characters for account description

### DIFF
--- a/app/models/account_details_form.rb
+++ b/app/models/account_details_form.rb
@@ -8,6 +8,8 @@ class AccountDetailsForm
 
   validates :account_name, :account_description, presence: true, length: { maximum: 256 }
 
+  validates_format_of :account_description, with: /\A[\w .:\/=+-@]+\z/, message: 'should only consist of alphanumeric characters, spaces and the characters .:/=+-@'
+
   def initialize(hash)
     params = hash.with_indifferent_access
     @account_name = params[:account_name]

--- a/test/controllers/account_details_controller_test.rb
+++ b/test/controllers/account_details_controller_test.rb
@@ -8,10 +8,16 @@ class AccountDetailsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test 'should validate form' do
-    post account_details_url, params: { account_details_form: { account_name: 'BAD ACCOUNT NAME', account_description: 'some description' } }
+  test 'should validate account name' do
+    post account_details_url, params: { account_details_form: { account_name: 'BAD ACCOUNT NAME', account_description: 'Some: description/using +permitted char@cters.' } }
     assert_response :success
     assert_select '.govuk-error-message', 'Error:Account name should be lower-case-separated-by-dashes'
+  end
+
+  test 'should validate account description' do
+    post account_details_url, params: { account_details_form: { account_name: 'good-account-name', account_description: 'A bad description,\ncausing trouble' } }
+    assert_response :success
+    assert_select '.govuk-error-message', 'Error:Account description should only consist of alphanumeric characters, spaces and the characters .:/=+-@'
   end
 
   test 'should redirect on valid form' do


### PR DESCRIPTION
Using minimal set of allowed characters sourced from https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html#tag-conventions

This should stop terraform failing when people include parentheses or commas etc.