### PR TITLE
accounts.tf: attempt to update .tf.json file to allow terraform upgrade

### DIFF
--- a/test/controllers/check_your_answers_controller_test.rb
+++ b/test/controllers/check_your_answers_controller_test.rb
@@ -123,6 +123,9 @@ class CheckYourAnswersControllerTest < ActionDispatch::IntegrationTest
     stub_request(:post, "#{ACCOUNT_MANAGEMENT_GITHUB_API}/git/refs").
       to_return(status: 200, body: '{}', headers: {'Content-Type' => 'application/json'})
 
+    stub_request(:get, "#{ACCOUNT_MANAGEMENT_GITHUB_API}/contents/terraform/accounts.tf.json").
+     to_return(status: 404, body: '{}', headers: {'Content-Type' => 'application/json'})
+
     stub_request(:get, "#{ACCOUNT_MANAGEMENT_GITHUB_API}/contents/terraform/accounts.tf").
      to_return(status: 200, body: accounts_terraform, headers: {'Content-Type' => 'application/json'})
 


### PR DESCRIPTION
Fall back to old `accounts.tf` file if `accounts.tf.json` is not found - we'll be renaming the file soon but don't want to have to synchronize a release of this app when we do.

This is to allow us to upgrade beyond terraform 0.11 and is my attempt at averting the note in https://re-team-manual.cloudapps.digital/gds-aws-account-management-service.html#run-the-terraform

~This part of the app doesn't have any tests at all and I'm not about to add them along with all the strange mocking that will be required. Tested on a local machine with a PAT.~ Wait whoah there are tests, I'll just have to find & fix them... (done)