### PR TITLE
AwsTagValueValidator.allowed_chars_regexp: fix regex to use dash at set end

### DIFF
--- a/app/lib/aws_tag_value_validator.rb
+++ b/app/lib/aws_tag_value_validator.rb
@@ -2,7 +2,7 @@ module AwsTagValueValidator
 
   # See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html#tag-conventions
   def self.allowed_chars_regexp
-    /\A[\w .:\/=+-@]*\z/
+    /\A[\w .:\/=+@-]*\z/
   end
 
   def self.allowed_chars_message

--- a/test/controllers/account_details_controller_test.rb
+++ b/test/controllers/account_details_controller_test.rb
@@ -14,14 +14,20 @@ class AccountDetailsControllerTest < ActionDispatch::IntegrationTest
     assert_select '.govuk-error-message', 'Error:Account name should be lower-case-separated-by-dashes'
   end
 
-  test 'should validate account description' do
-    post account_details_url, params: { account_details_form: { account_name: 'good-account-name', account_description: 'A bad description,\ncausing trouble' } }
+  test 'should validate account description (commas)' do
+    post account_details_url, params: { account_details_form: { account_name: 'good-account-name', account_description: 'A bad description, causing trouble' } }
+    assert_response :success
+    assert_select '.govuk-error-message', 'Error:Account description should only consist of alphanumeric characters, spaces and the characters .:/=+-@'
+  end
+
+  test 'should validate account description (various)' do
+    post account_details_url, params: { account_details_form: { account_name: 'good-account-name', account_description: 'A \n ~really~\nbad description; causing (great) trouble!' } }
     assert_response :success
     assert_select '.govuk-error-message', 'Error:Account description should only consist of alphanumeric characters, spaces and the characters .:/=+-@'
   end
 
   test 'should redirect on valid form' do
-    post account_details_url, params: { account_details_form: { account_name: 'good-account-name', account_description: 'some description' } }
+    post account_details_url, params: { account_details_form: { account_name: 'good-account-name', account_description: 'Some description - all valid.' } }
     assert_redirected_to organisation_url
   end
 end


### PR DESCRIPTION
Otherwise we're doing `+-@`, i.e. "plus to at", which conveniently includes comma.