### PR TITLE
Allow uppercase in emails

### DIFF
--- a/app/lib/email_validator.rb
+++ b/app/lib/email_validator.rb
@@ -19,10 +19,10 @@ module EmailValidator
   # which domains are allowed to be requested for a gds-users account
   def self.allowed_emails_regexp
     /\A(#{Regexp.union(
-      /([a-z.\-\']+@digital\.cabinet-office\.gov\.uk,?\s*)/,
-      /([a-z.\-\']+@cabinetoffice\.gov\.uk,?\s*)/,
-      /([a-z.\-\']+@softwire\.com,?\s*)/,
-      /([a-z.\-\']+@fidusinfosec\.com,?\s*)/,
+      /([a-zA-Z.\-\']+@digital\.cabinet-office\.gov\.uk,?\s*)/,
+      /([a-zA-Z.\-\']+@cabinetoffice\.gov\.uk,?\s*)/,
+      /([a-zA-Z.\-\']+@softwire\.com,?\s*)/,
+      /([a-zA-Z.\-\']+@fidusinfosec\.com,?\s*)/,
     )})+\z/
   end
 

--- a/test/lib/email_validator_test.rb
+++ b/test/lib/email_validator_test.rb
@@ -79,6 +79,11 @@ class EmailValidatorTest < ActiveSupport::TestCase
     assert_match EmailValidator.allowed_emails_regexp, emails
   end
 
+  test 'Mixed case emails are matched by the allowed emails regexp' do
+    email = 'Test.User@cabinetoffice.gov.uk'
+    assert_match EmailValidator.allowed_emails_regexp, email
+  end
+
   test 'Other email addresses should not match emails regexp' do
     email = 'fname.lname@example.com'
     assert_no_match EmailValidator.allowed_emails_regexp, email


### PR DESCRIPTION
This should fix #194 by allowing capital letters in the name portion of email addresses