### PR TITLE
bundle_and_release workflow: pin to `ubuntu-20.04`

### DIFF
--- a/.github/workflows/bundle_and_release.yml
+++ b/.github/workflows/bundle_and_release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 jobs:
   build-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     environment: production
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # V2.4.0


### PR DESCRIPTION
`ubuntu-latest` now being based on jammy doesn't include ruby 2.7.

We'll need to update this when we migrate the app to ruby 3.x.