### PR TITLE
Update workflow to use setup ruby action

### DIFF
--- a/.github/workflows/bundle_and_release.yml
+++ b/.github/workflows/bundle_and_release.yml
@@ -15,12 +15,16 @@ jobs:
         run: |
           wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
           echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
-        
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@e6689b4deb1cb2062ea45315001f687c0b52111b # V1.144.1
+        with:
+          ruby-version: '3.2'
+
       - name: install-system-dependencies
         run: |        
           sudo apt-get update
 
-          sudo apt-get install -y ruby=1:3.0~exp1
           sudo apt-get install -y nodejs=12.22.9~dfsg-1ubuntu3
           sudo apt-get install -y cf8-cli
           

--- a/.github/workflows/rubyandnode.yaml
+++ b/.github/workflows/rubyandnode.yaml
@@ -7,13 +7,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # V2.4.0
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@e6689b4deb1cb2062ea45315001f687c0b52111b # V1.144.1
       with:
         ruby-version: '3.2'
     - name: Set up Node
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # V3.6.0
       with:
         node-version: '12'
     - name: Build and test


### PR DESCRIPTION
It makes sense to use the same setup-ruby action as is used in the testing pipeline.

I have also updated the actions to use shas rather than tags.