### PR TITLE
Update GOV.UK Frontend to 4.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "re-request-an-aws-account",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "govuk-frontend": "^4.5.0"
+      }
+    },
+    "node_modules/govuk-frontend": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.5.0.tgz",
+      "integrity": "sha512-gZHDqf5vdlHjmx0NGJiNT12XLyR3d5KCS4AnlC3xTWOObJ0kQROrkIFyp3w4/PY3EQiYdgacVaJ6lizzygnzYw==",
+      "engines": {
+        "node": ">= 4.2.0"
+      }
+    }
+  },
+  "dependencies": {
+    "govuk-frontend": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.5.0.tgz",
+      "integrity": "sha512-gZHDqf5vdlHjmx0NGJiNT12XLyR3d5KCS4AnlC3xTWOObJ0kQROrkIFyp3w4/PY3EQiYdgacVaJ6lizzygnzYw=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "govuk-frontend": "^3.7.0"
+    "govuk-frontend": "^4.5.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"govuk-frontend@^3.7.0":
-  "integrity" "sha512-G3bqoKGGF8YQ18UJH9tTARrwB8i7iPwN1xc8RXwWyx91q0p/Xl10uNywZLkzGWcJDzEz1vwmBTTL3SLDU/KxNg=="
-  "resolved" "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.7.0.tgz"
-  "version" "3.7.0"
+"govuk-frontend@^4.5.0":
+  "integrity" "sha512-gZHDqf5vdlHjmx0NGJiNT12XLyR3d5KCS4AnlC3xTWOObJ0kQROrkIFyp3w4/PY3EQiYdgacVaJ6lizzygnzYw=="
+  "resolved" "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.5.0.tgz"
+  "version" "4.5.0"


### PR DESCRIPTION
We were using an old version of frontend and whilst poking about it made sense to do some software gardening and update this to 4.5.0