### PR TITLE
Remove PaaS reference and link

### DIFF
--- a/app/views/index/index.html.erb
+++ b/app/views/index/index.html.erb
@@ -55,25 +55,6 @@
       </p>
 
       <% if EmailValidator.email_is_allowed_advanced?(@email) %>
-      <h2 class="govuk-heading-m" id="request-cloud">
-        Request access to cloud computing resources
-      </h2>
-      <h3 class="govuk-heading-s">Request access to GOV.UK Platform-as-a-Service (PaaS)</h3>
-      <p>
-        If you need to host a web application or service in the cloud,
-        for example a blog, web form, or campaign site,
-        you should use <a class="govuk-link" href="https://www.cloud.service.gov.uk">GOV.UK PaaS</a>.
-      </p>
-      <p>GOV.UK PaaS is designed to meet the needs of government teams:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>UK hosted</li>
-        <li>It’s possible to test an application in the trial period free of charge</li>
-        <li>It offers 24-hour platform-level support</li>
-        <li>It meets the NCSC Cloud Security Principles</li>
-      </ul>
-      <a href="https://www.cloud.service.gov.uk" class="govuk-button" data-module="govuk-button">
-        Go to GOV.UK PaaS
-      </a>
 
       <h3 class="govuk-heading-s">Request a new AWS account (Infrastructure-as-a-Service)</h3>
       <p>If your application or service cannot run on GOV.UK PaaS, you can request a new AWS account.</p>


### PR DESCRIPTION
PaaS is no longer accepting new tenants, and as a result it makes little sense to keep this copy and link within the app.