### PR TITLE
Remove link as it is now dead

### DIFF
--- a/app/views/index/index.html.erb
+++ b/app/views/index/index.html.erb
@@ -12,11 +12,6 @@
             Manage user access to Amazon Web Services (AWS)
           </a>
         </li>
-        <li>
-          <a class="govuk-link" href="#request-cloud">
-            Request access to cloud computing resources
-          </a>
-        </li>
         <% else %>
         <li>
           <a class="govuk-link" href="#manage-users">


### PR DESCRIPTION
Remove the link that points to the no longer present PaaS copy.

I missed this in a previous PR