### PR TITLE
Improve content for adding and removing users

### DIFF
--- a/app/views/index/index.html.erb
+++ b/app/views/index/index.html.erb
@@ -24,16 +24,16 @@
       <h2 class="govuk-heading-m" id="manage-users">Manage user access to Amazon Web Services (AWS)</h2>
 
       <% if EmailValidator.email_is_allowed_advanced?(@email) %>
-      <h3 class="govuk-heading-s">Grant AWS access to a user</h3>
+      <h3 class="govuk-heading-s">Request a new AWS user</h3>
       <p>GDS manages a number of AWS accounts. Users for these accounts are managed centrally by reliability engineering with a base GDS account: <em>gds-users</em>.</p>
       <p>For a user to access resources in AWS they should be added to the <em>gds-users</em> base account and permitted to assume a role in the target account.</p>
       <p> See <a href="https://reliability-engineering.cloudapps.digital/iaas.html#access-aws-accounts">accessing AWS accounts</a> in the reliability engineering docs.</p>
       <p>Anyone within GDS or the Cabinet Office can request user access to AWS for one or more people.</p>
       <a href="<%= user_path %>" class="govuk-button" data-module="govuk-button">
-        Request user access
+        Request new user
       </a>
 
-      <h3 class="govuk-heading-s">Remove AWS access from a user</h3>
+      <h3 class="govuk-heading-s">Remove an AWS user</h3>
       <p>
         You should ensure that users are removed from <em>gds-users</em> as part of your team's leavers process.
         Users should only be removed when they leave GDS or no longer need access to any AWS resources.
@@ -69,8 +69,8 @@
       <p>Depending on your email domain, you can use this service to:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>Reset your AWS user password (for all users)</li>
-        <li>Grant AWS access to a user (e.g. for new joiners - Cabinet Office staff only)</li>
-        <li>Remove AWS access from a user (e.g. for leavers - Cabinet Office staff only)</li>
+        <li>Request a new AWS user (e.g. for new joiners - Cabinet Office staff only)</li>
+        <li>Remove an AWS user (e.g. for leavers - Cabinet Office staff only)</li>
         <li>Request a new AWS account (e.g. for a new service or environment - Cabinet Office staff only)</li>
       </ul>
       <p>First you need to sign in with your GDS or CO Google account so we know who you are.</p>

--- a/app/views/index/index.html.erb
+++ b/app/views/index/index.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Request an AWS account</h1>
+    <h1 class="govuk-heading-l">Manage AWS accounts and users</h1>
     <% if @email %>
       <p>You are logged in as <em><%= @email %></em>.</p>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
     <meta name="robots" content="noindex,nofollow">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 
-    <title>Request an AWS account</title>
+    <title>Manage AWS accounts and users</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">

--- a/app/views/remove_user/remove_user.html.erb
+++ b/app/views/remove_user/remove_user.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <a href="<%= index_path %>" class="govuk-back-link">Back</a>
-    <h1 class="govuk-heading-l">Revoke users access to AWS</h1>
+    <h1 class="govuk-heading-l">Request to remove an AWS user</h1>
     <%= error_summary_for(@form&.errors, :user_form) %>
     <p>When a user no longer requires any access to AWS (e.g. because they've left GDS) they should be removed from the <code>gds-users</code> base account.</p>
     <p>Please make sure the users do not require access to AWS on another team within GDS before requesting their removal.</p>

--- a/app/views/user/user.html.erb
+++ b/app/views/user/user.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <a href="<%= index_path %>" class="govuk-back-link">Back</a>
-    <h1 class="govuk-heading-l">Grant users access to AWS</h1>
+    <h1 class="govuk-heading-l">Request a new AWS user</h1>
     <%= error_summary_for(@form&.errors, :user_form) %>
     <p>To access GDS' AWS accounts users must be added to the <code>gds-users</code> base account.</p>
     <p>Having access to the base account does not give a user access to anything until target accounts allow that user to assume roles.</p>


### PR DESCRIPTION
This improves the site title to indicate the service can also be used to manage AWS users. (Previously it was just "Request a new AWS account").

This also improves wording around creating and deleting users. The actions are more consistent throughout the site and make it clearer that action are only "requests". It also re-phrases to the actions to refer to "AWS users" instead of "Grant/remove AWS Access", as creating the IAM user is usually not the only step required to "grant AWS access".