### PR TITLE
Replace reliability-engineering docs links

### DIFF
--- a/app/views/index/index.html.erb
+++ b/app/views/index/index.html.erb
@@ -27,7 +27,7 @@
       <h3 class="govuk-heading-s">Request a new AWS user</h3>
       <p>GDS manages a number of AWS accounts. Users for these accounts are managed centrally by reliability engineering with a base GDS account: <em>gds-users</em>.</p>
       <p>For a user to access resources in AWS they should be added to the <em>gds-users</em> base account and permitted to assume a role in the target account.</p>
-      <p> See <a href="https://reliability-engineering.cloudapps.digital/iaas.html#access-aws-accounts">accessing AWS accounts</a> in the reliability engineering docs.</p>
+      <p> See <a href="https://gds-way.digital.cabinet-office.gov.uk/manuals/working-with-aws-accounts.html#access-aws-accounts">accessing AWS accounts</a> in the GDS Way.</p>
       <p>Anyone within GDS or the Cabinet Office can request user access to AWS for one or more people.</p>
       <a href="<%= user_path %>" class="govuk-button" data-module="govuk-button">
         Request new user
@@ -58,8 +58,8 @@
       <p>When requesting non-GDS AWS accounts, you should provide the relevant Cabinet Office cost centre.</p>
       <p>
         More information is available on the
-        <a href="https://reliability-engineering.cloudapps.digital/iaas.html#create-aws-accounts">how to create AWS accounts</a> page
-        in the reliability engineering docs.
+        <a href="https://gds-way.digital.cabinet-office.gov.uk/manuals/working-with-aws-accounts.html#create-aws-accounts">how to create AWS accounts</a> page
+        in the GDS Way.
       </p>
       <a href="<%= account_details_path %>" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
         Request an account


### PR DESCRIPTION
The reliability-engineering wiki is being removed. There are two links to this wiki on the index page. Change these to point to the GDS Way version of the docs.