### PR TITLE
Eng-304

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Reliability Engineering: Request an AWS Account
+Engineering Enablement: Request an AWS Account
 ===============================================
 
 User interface to manage AWS Accounts (e.g. for new services or environments) and users within the base AWS account.

--- a/app/views/confirmation/account.html.erb
+++ b/app/views/confirmation/account.html.erb
@@ -19,9 +19,6 @@
     <p>
       They will create the account for you and email you with details when it's ready.
     </p>
-    <p>
-      Contact the team on slack channel <a href="https://gds.slack.com/messages/CAD6NP598">#reliability-eng</a> for support.
-    </p>
   </div>
 </div>
 

--- a/app/views/confirmation/account.html.erb
+++ b/app/views/confirmation/account.html.erb
@@ -13,12 +13,7 @@
     <h2 class="govuk-heading-m">
       What happens next?
     </h2>
-    <p>
-      You will receive confirmation that your AWS account can be billed through the central account.
-    </p>
-    <p>
-      They will create the account for you and email you with details when it's ready.
-    </p>
+    <p>Your request for a new AWS account will be reviewed, and if accepted, your new account will be created and the details will be emailed to you when ready.</p>
   </div>
 </div>
 

--- a/app/views/confirmation/account.html.erb
+++ b/app/views/confirmation/account.html.erb
@@ -14,7 +14,7 @@
       What happens next?
     </h2>
     <p>
-      Reliability engineering will confirm your AWS account can be billed through the central account.
+      Engineering Enablement will confirm your AWS account can be billed through the central account.
     </p>
     <p>
       They will create the account for you and email you with details when it's ready.

--- a/app/views/confirmation/account.html.erb
+++ b/app/views/confirmation/account.html.erb
@@ -14,7 +14,7 @@
       What happens next?
     </h2>
     <p>
-      Engineering Enablement will confirm your AWS account can be billed through the central account.
+      You will receive confirmation that your AWS account can be billed through the central account.
     </p>
     <p>
       They will create the account for you and email you with details when it's ready.

--- a/app/views/confirmation/remove_user.html.erb
+++ b/app/views/confirmation/remove_user.html.erb
@@ -14,7 +14,7 @@
       What happens next?
     </h2>
     <p>
-      Reliability engineering will remove your users from the gds-users base account. They'll send you an email once the work is complete.
+      Engineering Enablement will remove your users from the gds-users base account. They'll send you an email once the work is complete.
     </p>
   </div>
 </div>

--- a/app/views/confirmation/remove_user.html.erb
+++ b/app/views/confirmation/remove_user.html.erb
@@ -13,9 +13,7 @@
     <h2 class="govuk-heading-m">
       What happens next?
     </h2>
-    <p>
-      Engineering Enablement will remove your users from the gds-users base account. They'll send you an email once the work is complete.
-    </p>
+    <p>Your request to remove users from the gds-users base account will be reviewed, and if accepted, your users will be removed. You will receive an email once this is done.</p>
   </div>
 </div>
 

--- a/app/views/confirmation/remove_user.html.erb
+++ b/app/views/confirmation/remove_user.html.erb
@@ -16,9 +16,6 @@
     <p>
       Reliability engineering will remove your users from the gds-users base account. They'll send you an email once the work is complete.
     </p>
-    <p>
-      Contact the team on slack channel <a href="https://gds.slack.com/messages/CAD6NP598">#reliability-eng</a> for support.
-    </p>
   </div>
 </div>
 

--- a/app/views/confirmation/reset_password.html.erb
+++ b/app/views/confirmation/reset_password.html.erb
@@ -16,8 +16,5 @@
     <p>
       Reliability engineering will reset your gds-users IAM password. They'll send you an email once the work is complete.
     </p>
-    <p>
-      Contact the team on slack channel <a href="https://gds.slack.com/messages/CAD6NP598">#reliability-eng</a> for support.
-    </p>
   </div>
 </div>

--- a/app/views/confirmation/reset_password.html.erb
+++ b/app/views/confirmation/reset_password.html.erb
@@ -14,7 +14,7 @@
       What happens next?
     </h2>
     <p>
-      Engineering Enablement will reset your gds-users IAM password. They'll send you an email once the work is complete.
+      Your gds-users IAM password will be reset. You will be sent an email once the work is complete.
     </p>
   </div>
 </div>

--- a/app/views/confirmation/reset_password.html.erb
+++ b/app/views/confirmation/reset_password.html.erb
@@ -14,7 +14,7 @@
       What happens next?
     </h2>
     <p>
-      Reliability engineering will reset your gds-users IAM password. They'll send you an email once the work is complete.
+      Engineering Enablement will reset your gds-users IAM password. They'll send you an email once the work is complete.
     </p>
   </div>
 </div>

--- a/app/views/confirmation/user.html.erb
+++ b/app/views/confirmation/user.html.erb
@@ -14,7 +14,7 @@
       What happens next?
     </h2>
     <p>
-      Reliability Engineering will add your user to the gds-users base account. They'll send you an email with next steps once it's ready.
+      Engineering Enablement will add your user to the gds-users base account. They'll send you an email with next steps once it's ready.
     </p>
   </div>
 </div>

--- a/app/views/confirmation/user.html.erb
+++ b/app/views/confirmation/user.html.erb
@@ -14,7 +14,7 @@
       What happens next?
     </h2>
     <p>
-      Engineering Enablement will add your user to the gds-users base account. They'll send you an email with next steps once it's ready.
+      Your user will be added to the gds-users base account. You will be sent an email with next steps once it's ready.
     </p>
   </div>
 </div>

--- a/app/views/confirmation/user.html.erb
+++ b/app/views/confirmation/user.html.erb
@@ -16,8 +16,5 @@
     <p>
       Reliability Engineering will add your user to the gds-users base account. They'll send you an email with next steps once it's ready.
     </p>
-    <p>
-      For support, send a message to the <a href="https://gds.slack.com/messages/CAD6NP598">#reliability-eng</a> Slack channel, quoting your reference number.
-    </p>
   </div>
 </div>

--- a/app/views/index/index.html.erb
+++ b/app/views/index/index.html.erb
@@ -25,9 +25,8 @@
 
       <% if EmailValidator.email_is_allowed_advanced?(@email) %>
       <h3 class="govuk-heading-s">Request a new AWS user</h3>
-      <p>GDS manages a number of AWS accounts. Users for these accounts are managed centrally by Engineering Enablement with a base GDS account: <em>gds-users</em>.</p>
-      <p>For a user to access resources in AWS they should be added to the <em>gds-users</em> base account and permitted to assume a role in the target account.</p>
-      <p> See <a href="https://gds-way.digital.cabinet-office.gov.uk/manuals/working-with-aws-accounts.html#access-aws-accounts">accessing AWS accounts</a> in the GDS Way.</p>
+      <p>There are a number of ways of accessing your AWS accounts, but GDS recommends users use AWS's cross account access pattern.</p>
+      <p>To support this, GDS maintains a set of <a href="https://gds-way.digital.cabinet-office.gov.uk/manuals/working-with-aws-accounts.html#access-aws-accounts"centrally managed user identities in a base account called gds-users.</a></p>
       <p>Anyone within GDS or the Cabinet Office can request user access to AWS for one or more people.</p>
       <div class="govuk-inset-text">
         Processing time for this request is around 2 days
@@ -38,8 +37,7 @@
 
       <h3 class="govuk-heading-s">Remove an AWS user</h3>
       <p>
-        You should ensure that users are removed from <em>gds-users</em> as part of your team's leavers process.
-        Users should only be removed when they leave GDS or no longer need access to any AWS resources.
+        You should ensure that users are removed from <em>gds-users</em> as part of your team's leavers process. It is not sufficient to remove the role or trust policy from your AWS account, you must also remove the user from gds-users by submitting the form below. Only request removal when the person leaves GDS/CO or they no longer need access to any AWS resources.
       </p>
       <p>
         <div class="govuk-inset-text">
@@ -61,10 +59,14 @@
       <% if EmailValidator.email_is_allowed_advanced?(@email) %>
 
       <h3 class="govuk-heading-s">Request a new AWS account (Infrastructure-as-a-Service)</h3>
-      <p>If your application or service cannot run on GOV.UK PaaS, you can request a new AWS account.</p>
-      <p>You can provision infrastructure directly from Amazon Web Services, you may need specialist capabilities to maintain this infrastructure.</p>
-      <p>You may need multiple accounts, one for each environment, for example development, staging, and production.</p>
-      <p>When requesting non-GDS AWS accounts, you should provide the relevant Cabinet Office cost centre.</p>
+      <p>Use this form to request a new AWS account. Before requesting an account you must:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>Have prior financial approval from your business unit</li>
+        <li>Know the relevant Cabinet Office cost centre and provide it when making your request</li>
+        <li>ensure you have the required skills and capabilities to properly maintain, manage and ultimately decommission any services created, including adhering to all relevant Cabinet Office, GDS security policies, technical policies and standards </li>
+        <li>Ensure you have plans in place to manage credentials and users securely, including removing leavers before or immediately after their last day with your organisation.</li>
+      </ul>
+      
       <p>
         More information is available on the
         <a href="https://gds-way.digital.cabinet-office.gov.uk/manuals/working-with-aws-accounts.html#create-aws-accounts">how to create AWS accounts</a> page
@@ -94,4 +96,3 @@
     <% end %>
   </div>
 </div>
-

--- a/app/views/index/index.html.erb
+++ b/app/views/index/index.html.erb
@@ -44,6 +44,9 @@
       <p>For a user to access resources in AWS they should be added to the <em>gds-users</em> base account and permitted to assume a role in the target account.</p>
       <p> See <a href="https://gds-way.digital.cabinet-office.gov.uk/manuals/working-with-aws-accounts.html#access-aws-accounts">accessing AWS accounts</a> in the GDS Way.</p>
       <p>Anyone within GDS or the Cabinet Office can request user access to AWS for one or more people.</p>
+      <div class="govuk-inset-text">
+        Average processing time for this request is up to 2 days
+      </div>
       <a href="<%= user_path %>" class="govuk-button" data-module="govuk-button">
         Request new user
       </a>
@@ -54,6 +57,9 @@
         Users should only be removed when they leave GDS or no longer need access to any AWS resources.
       </p>
       <p>
+        <div class="govuk-inset-text">
+          Average processing time for this request is up to 2 days
+        </div>
         <a href="<%= remove_user_path %>" class="govuk-button govuk-button--warning" data-module="govuk-button">Request user removal</a>
       </p>
       <% end %>
@@ -61,6 +67,9 @@
       <h3 class="govuk-heading-s">Reset your AWS user password</h3>
       <p>If you need to reset your AWS password, you can do that here as well.</p>
       <p>
+        <div class="govuk-inset-text">
+          Average processing time for this request is up to 2 days
+        </div>
         <a href="<%= reset_password_path %>" class="govuk-button" data-module="govuk-button">Request password reset</a>
       </p>
 
@@ -76,6 +85,9 @@
         <a href="https://gds-way.digital.cabinet-office.gov.uk/manuals/working-with-aws-accounts.html#create-aws-accounts">how to create AWS accounts</a> page
         in the GDS Way.
       </p>
+      <div class="govuk-inset-text">
+        Average processing time for this request is up to 7 days
+      </div>
       <a href="<%= account_details_path %>" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
         Request an account
       </a>

--- a/app/views/index/index.html.erb
+++ b/app/views/index/index.html.erb
@@ -40,7 +40,7 @@
 
       <% if EmailValidator.email_is_allowed_advanced?(@email) %>
       <h3 class="govuk-heading-s">Request a new AWS user</h3>
-      <p>GDS manages a number of AWS accounts. Users for these accounts are managed centrally by reliability engineering with a base GDS account: <em>gds-users</em>.</p>
+      <p>GDS manages a number of AWS accounts. Users for these accounts are managed centrally by Engineering Enablement with a base GDS account: <em>gds-users</em>.</p>
       <p>For a user to access resources in AWS they should be added to the <em>gds-users</em> base account and permitted to assume a role in the target account.</p>
       <p> See <a href="https://gds-way.digital.cabinet-office.gov.uk/manuals/working-with-aws-accounts.html#access-aws-accounts">accessing AWS accounts</a> in the GDS Way.</p>
       <p>Anyone within GDS or the Cabinet Office can request user access to AWS for one or more people.</p>

--- a/app/views/index/index.html.erb
+++ b/app/views/index/index.html.erb
@@ -1,3 +1,18 @@
+<% if @email %>
+<div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+  <div class="govuk-notification-banner__header">
+    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+      Notice
+    </h2>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <p class="govuk-notification-banner__heading">
+    This Request an AWS Account Tool is now owned by the GDS Engineering Enablement Team. For support, please contact <a href="mailto:gds-engineering-enablement-team@digital.cabinet-office.gov.uk">gds-engineering-enablement-team@digital.cabinet-office.gov.uk</a>
+    </p>
+  </div>
+</div>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Manage AWS accounts and users</h1>

--- a/app/views/index/index.html.erb
+++ b/app/views/index/index.html.erb
@@ -61,10 +61,10 @@
       <h3 class="govuk-heading-s">Request a new AWS account (Infrastructure-as-a-Service)</h3>
       <p>Use this form to request a new AWS account. Before requesting an account you must:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>Have prior financial approval from your business unit</li>
-        <li>Know the relevant Cabinet Office cost centre and provide it when making your request</li>
-        <li>ensure you have the required skills and capabilities to properly maintain, manage and ultimately decommission any services created, including adhering to all relevant Cabinet Office, GDS security policies, technical policies and standards </li>
-        <li>Ensure you have plans in place to manage credentials and users securely, including removing leavers before or immediately after their last day with your organisation.</li>
+        <li>have prior <b>financial approval</b> from your business unit</li>
+        <li>know the relevant Cabinet Office <b>cost centre code</b> and provide it when making your request</li>
+        <li>ensure you have the required <b>skills and capabilities</b> to maintain, manage and decommission any services created, including adhering to all relevant Cabinet Office/GDS security policies, technical policies and standards </li>
+        <li>ensure you have plans in place to <b>manage credentials and users securely</b>, including removing leavers before or immediately after their last day with your organisation.</li>
       </ul>
       
       <p>

--- a/app/views/index/index.html.erb
+++ b/app/views/index/index.html.erb
@@ -26,7 +26,7 @@
       <% if EmailValidator.email_is_allowed_advanced?(@email) %>
       <h3 class="govuk-heading-s">Request a new AWS user</h3>
       <p>There are a number of ways of accessing your AWS accounts, but GDS recommends users use AWS's cross account access pattern.</p>
-      <p>To support this, GDS maintains a set of <a href="https://gds-way.digital.cabinet-office.gov.uk/manuals/working-with-aws-accounts.html#access-aws-accounts"centrally managed user identities in a base account called gds-users.</a></p>
+      <p>To support this, GDS maintains a set of <a href="https://gds-way.digital.cabinet-office.gov.uk/manuals/working-with-aws-accounts.html#access-aws-accounts">centrally managed user identities in a base account called gds-users.</a></p>
       <p>Anyone within GDS or the Cabinet Office can request user access to AWS for one or more people.</p>
       <div class="govuk-inset-text">
         Processing time for this request is around 2 days

--- a/app/views/index/index.html.erb
+++ b/app/views/index/index.html.erb
@@ -1,18 +1,3 @@
-<% if @email %>
-<div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-  <div class="govuk-notification-banner__header">
-    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-      Notice
-    </h2>
-  </div>
-  <div class="govuk-notification-banner__content">
-    <p class="govuk-notification-banner__heading">
-    This Request an AWS Account Tool is now owned by the GDS Engineering Enablement Team. For support, please contact <a href="mailto:gds-engineering-enablement-team@digital.cabinet-office.gov.uk">gds-engineering-enablement-team@digital.cabinet-office.gov.uk</a>
-    </p>
-  </div>
-</div>
-<% end %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Manage AWS accounts and users</h1>
@@ -45,7 +30,7 @@
       <p> See <a href="https://gds-way.digital.cabinet-office.gov.uk/manuals/working-with-aws-accounts.html#access-aws-accounts">accessing AWS accounts</a> in the GDS Way.</p>
       <p>Anyone within GDS or the Cabinet Office can request user access to AWS for one or more people.</p>
       <div class="govuk-inset-text">
-        Average processing time for this request is up to 2 days
+        Processing time for this request is around 2 days
       </div>
       <a href="<%= user_path %>" class="govuk-button" data-module="govuk-button">
         Request new user
@@ -58,7 +43,7 @@
       </p>
       <p>
         <div class="govuk-inset-text">
-          Average processing time for this request is up to 2 days
+          Processing time for this request is around 2 days
         </div>
         <a href="<%= remove_user_path %>" class="govuk-button govuk-button--warning" data-module="govuk-button">Request user removal</a>
       </p>
@@ -68,11 +53,11 @@
       <p>If you need to reset your AWS password, you can do that here as well.</p>
       <p>
         <div class="govuk-inset-text">
-          Average processing time for this request is up to 2 days
+          Processing time for this request is around 2 days
         </div>
         <a href="<%= reset_password_path %>" class="govuk-button" data-module="govuk-button">Request password reset</a>
       </p>
-
+      
       <% if EmailValidator.email_is_allowed_advanced?(@email) %>
 
       <h3 class="govuk-heading-s">Request a new AWS account (Infrastructure-as-a-Service)</h3>
@@ -86,7 +71,7 @@
         in the GDS Way.
       </p>
       <div class="govuk-inset-text">
-        Average processing time for this request is up to 7 days
+        Processing time for this request is around 2 weeks
       </div>
       <a href="<%= account_details_path %>" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
         Request an account

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -46,7 +46,7 @@
 
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper " id="main-content" role="main">
-        <% if @email %>
+      <% if @email or !current_page?('')%>
         <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
           <div class="govuk-notification-banner__header">
             <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,7 @@
       <div class="govuk-header__container govuk-width-container">
         <div class="govuk-header__logo">
           <div class="govuk-header__product-name">
-            Reliability Engineering
+            Engineering Enablement
             <strong class="govuk-tag govuk-phase-banner__content__tag">
               INTERNAL
             </strong>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -56,7 +56,7 @@
           <div class="govuk-notification-banner__content">
             <p class="govuk-notification-banner__heading">
             This tool is now owned by the GDS Engineering Enablement Team. For support, please contact:<br>
-            <a href="mailto:gds-engineering-enablement-team@digital.cabinet-office.gov.uk">gds-engineering-enablement-team@digital.cabinet-office.gov.uk</a>
+            <%= link_to(Rails.application.config.support_email) %>
             </p>
           </div>
         </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -46,6 +46,22 @@
 
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper " id="main-content" role="main">
+        <% if @email %>
+        <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+          <div class="govuk-notification-banner__header">
+            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+              Update
+            </h2>
+          </div>
+          <div class="govuk-notification-banner__content">
+            <p class="govuk-notification-banner__heading">
+            This tool is now owned by the GDS Engineering Enablement Team. For support, please contact:<br>
+            <a href="mailto:gds-engineering-enablement-team@digital.cabinet-office.gov.uk">gds-engineering-enablement-team@digital.cabinet-office.gov.uk</a>
+            </p>
+          </div>
+        </div>
+        <% end %>
+
         <%= content_for?(:main) ? yield(:main) : yield %>
       </main>
     </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,6 +33,8 @@ module ReRequestAnAwsAccount
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w(assets tasks))
 
+    config.support_email = "gds-engineering-enablement-support@digital.cabinet-office.gov.uk"
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files


### PR DESCRIPTION
Add a banner to every page of the RAAT tool  (except the page you can view without being signed in) stating: 
“This Request an AWS Account Tool is owned by the GDS Engineering Enablement Team. For support, please contact gds-engineering-enablement-team@digital.cabinet-office.gov.uk”

Immediately before the button ‘Request an account’ add “Average processing time for this request is up to 7 days”

Immediately before each of the buttons 'Request new user', ‘Request user removal’, ‘Request password reset’ add text in Bold which states “Average processing time for this request is up to 2 days”

Find and remove any references to the #reliability-eng channel for support. 

![screencapture-localhost-3000-2024-06-10-10_07_38](https://github.com/alphagov/re-request-an-aws-account/assets/1826895/3f5608ff-74fd-4a48-bd41-c9f90e292a25)

