### PR TITLE
Make app resilient to S3 or other errors on cost centre startup.

### DIFF
--- a/config/initializers/cost_centers.rb
+++ b/config/initializers/cost_centers.rb
@@ -16,9 +16,9 @@ end
 def get_cost_centre_data()
   begin
     return load_from_s3(ENV['COST_CENTRE_S3_BUCKET_NAME'], 'cost_centres.csv')
-  rescue Aws::S3::Errors::ServiceError
+  rescue Aws::S3::Errors::ServiceError, Aws::Errors::MissingRegionError
     Rails.logger.error("Failed unable to retrieve cost_centres.csv from s3")
-    return File.read(File.join(Rails.root, 'config', 'cost_centre_fixture.csv'))    
+    return File.read(File.join(Rails.root, 'config', 'cost_centre_fixture.csv'))
   end
 end
 


### PR DESCRIPTION
This fixes an issue where the app will fail to start if there is any sort of error getting data from S3.
If there is the app will start with out test fixure loaded.

The app will raise an error log beginning with Failed which will be picked up by our metric filter.