### PR TITLE
Include mapping between csv headers and the fields used in app

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ Production environment:
 - Bucket name: ```gds-ee-raat-csv```
 
 Path to file is from the root of the project eg ```/app/cost_centres.csv```.
+
+The script checks that the headers in the CSV have the expected values. If the upload fails because the headers have been changed, you need to update the keys accordingly in the ```mapping``` hash in the ```/bin/csv_updater``` file.  
+
 **Important note:** The csv file should not be made public, so if you save it inside the project, ensure you delete it after running the script and DO NOT push it to GitHub. 
 
 **To apply the changes, you must restart the app.** 

--- a/bin/csv_updater
+++ b/bin/csv_updater
@@ -4,6 +4,15 @@ require 'aws-sdk-s3'
 require 'csv'
 require 'slop'
 
+# key value pair mapping from headers in the ingested csv file to the headers required by the RAAT.
+# if required headers are not found adjust the keys to match the updated headers in the new file.
+mapping = {
+  "Cost Centre Description" => "Cost Centre Description",
+  "Cost Centre" => "Cost Centre",
+  "Operating Unit Description" => "Operating Unit Description",
+  "Parent Cost Centre Description" => "Parent Cost Centre Description"
+}
+
 puts "Running csv updater"
 
 options = Slop.parse do |opts|
@@ -20,38 +29,50 @@ end
 bucket_name = options[:bucket]
 file_path = File.join(Dir.pwd, options[:'file-path'])
 
-csv_file_headers = CSV.open(file_path, 'r') { |csv| csv.first }
 
 
 def validate_csv_format(csv_file_headers)
   required_headers = ["Cost Centre Description", "Cost Centre", "Operating Unit Description", "Parent Cost Centre Description"]
   is_valid = required_headers.all? { |header| csv_file_headers.include?(header)}
   if not is_valid
-    STDERR.puts "The required headers are not present in the csv file."   
+    STDERR.puts "The required headers: #{required_headers} are not present in the csv file. Please update the mapping in this script and re-run it to continue"   
   else
     puts "The file is in valid a format"
   end
   is_valid
 end
 
-def upload_to_s3(file, bucket)
+def upload_to_s3(csv, bucket)
   s3 = Aws::S3::Client.new
-  File.open(file, 'rb') do |body|
-    begin
+
+  begin
       s3.put_object(
-        body: body,
-        bucket: bucket,
-        key: "cost_centres.csv"
-        )
+      body: csv,
+      bucket: bucket,
+      key: "cost_centres.csv"
+      )
       puts "Successfully uploaded file"
-    rescue Aws::S3::Errors::ServiceError => error
+  rescue Aws::S3::Errors::ServiceError => error
       STDERR.puts "File not uploaded: #{error.message}"
+  end
+end
+
+def map_csv_headers(csv, mapping)
+  CSV.generate do | out_csv |
+    out_csv << mapping.keys
+    CSV.foreach(csv, headers: true) do |in_row|
+      out_row = []
+      mapping.each do |old_header, new_header|
+        out_row.append(in_row[old_header])
+      end
+      out_csv << out_row
     end
   end
 end
 
-if validate_csv_format(csv_file_headers)
-  upload_to_s3(file_path, bucket_name)
+if validate_csv_format(CSV.open(file_path, 'r').first)
+  mapped_csv = map_csv_headers(file_path, mapping)
+  upload_to_s3(mapped_csv, bucket_name)
   exit 0
 end
 exit 1


### PR DESCRIPTION
We have a mapping, so if the headers of the cost centre csv are changed, we only have to update them in the csv_updater script, and not in other places in the codebase. 

The file uploaded to S3 now only contains the fields used by this app, instead of everything in the source csv.