### PR TITLE
Eng 290 sanitise tags

### DIFF
--- a/app/services/terraform_accounts_service.rb
+++ b/app/services/terraform_accounts_service.rb
@@ -26,12 +26,7 @@ class TerraformAccountsService
         'email': AWS_ROOT_ACCOUNTS_EMAIL_FORMAT % truncate_account_name_for_email(account_name),
         'role_name': 'bootstrap',
         'iam_user_access_to_billing': 'ALLOW',
-        'tags': tags,
-        'lifecycle': {
-          'ignore_changes': [
-            'tags'
-          ]
-        }
+        'tags': tags
       }
     })
 

--- a/test/controllers/check_your_answers_controller_test.rb
+++ b/test/controllers/check_your_answers_controller_test.rb
@@ -91,8 +91,7 @@ class CheckYourAnswersControllerTest < ActionDispatch::IntegrationTest
             "billing-cost-centre" => "87654321",
             "billing-business-unit" => "some-business-unit",
             "billing-business-unit-subsection" => "some-subsection"      
-          },
-          "lifecycle" => { "ignore_changes" => ["tags"]}
+          }
         }
       },
       accounts_terraform_after['resource'][0]['aws_organizations_account']
@@ -174,8 +173,7 @@ class CheckYourAnswersControllerTest < ActionDispatch::IntegrationTest
             "out-of-hours-support-phone-number" => "000000000000",
             "out-of-hours-support-pagerduty-link" => "https://pagerduty.example.com",
             "out-of-hours-support-email-address" => "outofhours@example.com"
-          },
-          "lifecycle" => { "ignore_changes" => ["tags"]}
+          }
         }
       },
       accounts_terraform_after['resource'][0]['aws_organizations_account']
@@ -240,8 +238,7 @@ class CheckYourAnswersControllerTest < ActionDispatch::IntegrationTest
             "security-critical-resources-description" => "User data stored in blah S3 bucket",
             "security-does-account-hold-pii" => "true",
             "security-does-account-hold-pci-data" => "false"
-          },
-          "lifecycle" => { "ignore_changes" => ["tags"]}
+          }
         }
       },
       accounts_terraform_after['resource'][0]['aws_organizations_account']

--- a/test/services/terraform_accounts_service_test.rb
+++ b/test/services/terraform_accounts_service_test.rb
@@ -9,8 +9,7 @@ INITIAL_ACCOUNTS_TERRAFORM = <<EOTERRAFORM
           "name": "wombles-of-wimbledon-common-prod",
           "email": "aws-root-accounts+wom-of-wim-pro@digital.cabinet-office.gov.uk",
           "role_name": "bootstrap",
-          "iam_user_access_to_billing": "ALLOW",
-          "lifecycle": {"ignore_changes": ["tags"]}
+          "iam_user_access_to_billing": "ALLOW"
         }
       }
     },
@@ -20,8 +19,7 @@ INITIAL_ACCOUNTS_TERRAFORM = <<EOTERRAFORM
           "name": "wombles-of-wimbledon-common-staging",
           "email": "aws-root-accounts+wom-of-wim-sta@digital.cabinet-office.gov.uk",
           "role_name": "bootstrap",
-          "iam_user_access_to_billing": "ALLOW",
-          "lifecycle": {"ignore_changes": ["tags"]}
+          "iam_user_access_to_billing": "ALLOW" 
         }
       }
     }
@@ -55,5 +53,19 @@ class TerraformAccountsServiceTest < ActiveSupport::TestCase
     assert_equal result, JSON.pretty_generate(JSON.parse(result)) + "\n"
     result_tags = JSON.parse(result)["resource"][0]["aws_organizations_account"]['gds-wombles-of-wimbledon-test']['tags']
     assert_equal expected_tags, result_tags
+  end
+
+  test 'Doesnt add lifecycle policy ignore tags' do
+    terraform_accounts_service = TerraformAccountsService.new(INITIAL_ACCOUNTS_TERRAFORM)
+    tags = {
+      'description' => 'Description.'
+    }
+    result = terraform_accounts_service.add_account(
+      'gds-wombles-of-wimbledon-test',
+      tags
+    )
+
+    has_lifecycle = JSON.parse(result)["resource"][0]["aws_organizations_account"]['gds-wombles-of-wimbledon-test'].has_key?('lifecycle')
+    assert_equal false, has_lifecycle
   end
 end


### PR DESCRIPTION
Does 2 things

- ensures that tags conform to the allowed characters in [tagging restrictions ](https://docs.aws.amazon.com/mediaconnect/latest/ug/tagging-restrictions.html)
- removes the lifecycle policy for accounts created via the RAAT so that tags are managed by terraform.