### PR TITLE
ENG-462: Allow GPA email addresses to log in and request new users and accounts

### DIFF
--- a/app/lib/email_validator.rb
+++ b/app/lib/email_validator.rb
@@ -7,6 +7,7 @@ module EmailValidator
     end
     return true if email.end_with? '@digital.cabinet-office.gov.uk'
     return true if email.end_with? '@cabinetoffice.gov.uk'
+    return true if email.end_with? '@gpa.gov.uk'
     return true if email.end_with? '@softwire.com'
     return true if email.end_with? '@fidusinfosec.com'
     return true if email.end_with? '@cyberis.com'
@@ -21,6 +22,7 @@ module EmailValidator
     end
     return true if email.end_with? '@digital.cabinet-office.gov.uk'
     return true if email.end_with? '@cabinetoffice.gov.uk'
+    return true if email.end_with? '@gpa.gov.uk'
     false
   end
 
@@ -29,6 +31,7 @@ module EmailValidator
     /\A(#{Regexp.union(
       /([a-z0-9.\-\']+@digital\.cabinet-office\.gov\.uk,?\s*)/,
       /([a-z0-9.\-\']+@cabinetoffice\.gov\.uk,?\s*)/,
+      /([a-z0-9.\-\']+@gpa\.gov\.uk,?\s*)/,
       /([a-z0-9.\-\']+@softwire\.com,?\s*)/,
       /([a-z0-9.\-\']+@fidusinfosec\.com,?\s*)/,
       /([a-z0-9.\-\']+@cyberis\.com,?\s*)/,

--- a/test/lib/email_validator_test.rb
+++ b/test/lib/email_validator_test.rb
@@ -11,6 +11,11 @@ class EmailValidatorTest < ActiveSupport::TestCase
     assert EmailValidator.email_is_allowed_basic?(email)
   end
 
+  test 'Government Property Agency email addresses are allowed to sign in' do
+    email = 'fname.lname@gpa.gov.uk'
+    assert EmailValidator.email_is_allowed_basic?(email)
+  end
+
   test 'Softwire email addresses are allowed to sign in' do
     email = 'fname.lname@softwire.com'
     assert EmailValidator.email_is_allowed_basic?(email)
@@ -46,6 +51,11 @@ class EmailValidatorTest < ActiveSupport::TestCase
     assert EmailValidator.email_is_allowed_advanced?(email)
   end
 
+  test 'Government Property Agency email addresses are allowed to manage users' do
+    email = 'fname.lname@gpa.gov.uk'
+    assert EmailValidator.email_is_allowed_advanced?(email)
+  end
+
   test 'Softwire email addresses are not allowed to manage users' do
     email = 'fname.lname@softwire.com'
     assert ! EmailValidator.email_is_allowed_advanced?(email)
@@ -73,6 +83,11 @@ class EmailValidatorTest < ActiveSupport::TestCase
 
   test 'Cabinet Office emails are matched by the allowed emails regexp' do
     email = 'fname.lname@cabinetoffice.gov.uk'
+    assert_match EmailValidator.allowed_emails_regexp, email
+  end
+
+  test 'Government Property Agency emails can be used as usernames for new users' do
+    email = 'fname.lname@gpa.gov.uk'
     assert_match EmailValidator.allowed_emails_regexp, email
   end
 


### PR DESCRIPTION
Folks in the Government Property Agency need to be able to access the request-an-aws-account app to request new accounts and users and password resets. Although they are part of the cabinetoffice.gov.uk Google Workspace, they all use emails with the gpa.gov.uk domain.

Allow gpa.gov.uk emails both basic and advanced access to the app to allow them to do what they need to do without having to ask Cabinet Office Digital to do it for them.