### PR TITLE
Update the cost centres intranet page URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ We have a csv file in S3 which contains the Cabinet Office cost centre informati
 
 You will need to be on the VPN both to access the file on the intranet, and to upload to to S3. 
 
-Download the Cost Center Hierarchy file available on this page: <https://intranet.cabinetoffice.gov.uk/wagtail-user-sandbox-area/cdt-information-hub/co-reporting/cabinet-office-cost-centres/>, and export to a CSV if in another format.
+Download the Cost Center Hierarchy CSV file available on [this Cabinet Office intranet page](https://intranet.cabinetoffice.gov.uk/managing-people-and-services/corporate-services-directory/cdt-information-hub/co-reporting/cabinet-office-cost-centres/).
 
 Run the CSV Updater script from the root of the project with:
 ```sh

--- a/app/views/organisation/organisation.html.erb
+++ b/app/views/organisation/organisation.html.erb
@@ -23,7 +23,7 @@
             Who is paying for the account?
           </h1>
         </legend>
-        <p class=govuk-body>You must confirm who is paying for this account. In most cases this is by a recharge to a cost centre in others we invoice your business unit directly. You must have the budget holder's permission before continuing. You can find Cabinet Office cost centres <a href="https://intranet.cabinetoffice.gov.uk/wagtail-user-sandbox-area/cdt-information-hub/co-reporting/cabinet-office-cost-centres/" class=govuk-link>here</a>. (You must be on the VPN.)</p>
+        <p class=govuk-body>You must confirm who is paying for this account. In most cases this is by a recharge to a cost centre in others we invoice your business unit directly. You must have the budget holder's permission before continuing. You can find Cabinet Office cost centres <a href="https://intranet.cabinetoffice.gov.uk/managing-people-and-services/corporate-services-directory/cdt-information-hub/co-reporting/cabinet-office-cost-centres/" class=govuk-link>here</a>. (You must be on the VPN.)</p>
         <div class="govuk-form-group <%= 'govuk-form-group--error' if @form.errors.any? %>">
           <span id="value-error" class="govuk-error-message">
             <span class="govuk-visually-hidden">Error:</span><%= @form.errors[:organisation_specified].first %>


### PR DESCRIPTION
The location of the cost centres intranet page has changed again. The old URL is currently redirecting to the new one, but that might stop at some point, so we need to update the app to use the correct URL. It is used both in the README and on the organisation page of the app.