### PR TITLE
Add ipa.gov.uk email domain to allowed list for RAAT

### DIFF
--- a/app/lib/email_validator.rb
+++ b/app/lib/email_validator.rb
@@ -8,6 +8,7 @@ module EmailValidator
     return true if email.end_with? '@digital.cabinet-office.gov.uk'
     return true if email.end_with? '@cabinetoffice.gov.uk'
     return true if email.end_with? '@gpa.gov.uk'
+    return true if email.end_with? '@ipa.gov.uk'
     return true if email.end_with? '@softwire.com'
     return true if email.end_with? '@fidusinfosec.com'
     return true if email.end_with? '@cyberis.com'
@@ -23,6 +24,7 @@ module EmailValidator
     return true if email.end_with? '@digital.cabinet-office.gov.uk'
     return true if email.end_with? '@cabinetoffice.gov.uk'
     return true if email.end_with? '@gpa.gov.uk'
+    return true if email.end_with? '@ipa.gov.uk'
     false
   end
 
@@ -32,6 +34,7 @@ module EmailValidator
       /([a-z0-9.\-\']+@digital\.cabinet-office\.gov\.uk,?\s*)/,
       /([a-z0-9.\-\']+@cabinetoffice\.gov\.uk,?\s*)/,
       /([a-z0-9.\-\']+@gpa\.gov\.uk,?\s*)/,
+      /([a-z0-9.\-\']+@ipa\.gov\.uk,?\s*)/,
       /([a-z0-9.\-\']+@softwire\.com,?\s*)/,
       /([a-z0-9.\-\']+@fidusinfosec\.com,?\s*)/,
       /([a-z0-9.\-\']+@cyberis\.com,?\s*)/,

--- a/test/lib/email_validator_test.rb
+++ b/test/lib/email_validator_test.rb
@@ -16,6 +16,11 @@ class EmailValidatorTest < ActiveSupport::TestCase
     assert EmailValidator.email_is_allowed_basic?(email)
   end
 
+  test 'Infrastructure and Projects Authority email addresses are allowed to sign in' do
+    email = 'fname.lname@ipa.gov.uk'
+    assert EmailValidator.email_is_allowed_basic?(email)
+  end
+
   test 'Softwire email addresses are allowed to sign in' do
     email = 'fname.lname@softwire.com'
     assert EmailValidator.email_is_allowed_basic?(email)
@@ -56,6 +61,11 @@ class EmailValidatorTest < ActiveSupport::TestCase
     assert EmailValidator.email_is_allowed_advanced?(email)
   end
 
+  test 'Infrastructure and Projects Authority email addresses are allowed to manage users' do
+    email = 'fname.lname@ipa.gov.uk'
+    assert EmailValidator.email_is_allowed_advanced?(email)
+  end
+
   test 'Softwire email addresses are not allowed to manage users' do
     email = 'fname.lname@softwire.com'
     assert ! EmailValidator.email_is_allowed_advanced?(email)
@@ -88,6 +98,11 @@ class EmailValidatorTest < ActiveSupport::TestCase
 
   test 'Government Property Agency emails can be used as usernames for new users' do
     email = 'fname.lname@gpa.gov.uk'
+    assert_match EmailValidator.allowed_emails_regexp, email
+  end
+
+  test 'Infrastructure and Projects Authority emails can be used as usernames for new users' do
+    email = 'fname.lname@ipa.gov.uk'
     assert_match EmailValidator.allowed_emails_regexp, email
   end
 


### PR DESCRIPTION
- Allow Infrastructure and Projects Authority (IPA) email addresses to sign in and manage users
- Update EmailValidator to include @ipa.gov.uk domain for basic and advanced access
- Add corresponding unit tests for new email domain validation