### PR TITLE
Ignore ruby major version changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,11 +17,8 @@ updates:
     - 3.12.0
     - 3.12.1
   - dependency-name: rails
-    versions:
-    - 6.1.1
-    - 6.1.2
-    - 6.1.2.1
-    - 6.1.3
+    update-types:
+      - version-update:semver-major
 
 - package-ecosystem: "docker"
   directory: "/"


### PR DESCRIPTION
Upgrading ruby major version is sometimes slightly involved, so we don't want dependabot just suggesting that, it needs to be a planned piece of wrok