### PR TITLE
ENG-780 Use arial instead of default govuk font family

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,6 @@
 $govuk-global-styles: true;
 $govuk-images-path: "govuk-frontend/govuk/assets/images/";
-$govuk-fonts-path: "govuk-frontend/govuk/assets/fonts/";
+$govuk-font-family: arial, sans-serif;
 @import "govuk-frontend/govuk/all";
 
 .govuk-header__product-name {


### PR DESCRIPTION
### Before
<img width="954" alt="image" src="https://github.com/user-attachments/assets/30ac6f80-8497-4564-90ca-ffa2d7fd19bc" />

### After
<img width="956" alt="image" src="https://github.com/user-attachments/assets/02379863-6fa9-4184-af98-e5737e7753c1" />

