### PR TITLE
fix dependency errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,11 @@ RUN apk update && apk add --no-cache \
 
 WORKDIR /opt/app
 COPY Gemfile Gemfile.lock ./
-RUN bundle config set without development
-RUN bundle config set without test
-RUN bundle config --delete without
-RUN bundle config --delete with
-RUN bundle install
+RUN bundle config set without development && \
+bundle config set without test && \
+bundle config --delete without && \
+bundle config --delete with && \
+bundle install
 
 # copy required files from base images, precompile assets & cleanup
 FROM ruby:3.3.5-alpine


### PR DESCRIPTION
Fixes this error, introduced by some or other dependabot dependency change:

```
=> Run `bin/rails server --help` for more startup options
Exiting
/usr/local/bundle/gems/bundler-2.5.19/lib/bundler/rubygems_integration.rb:237:in `block (2 levels) in replace_gem': listen is not part of the bundle. Add it to your Gemfile. (Gem::LoadError)
	from /usr/local/bundle/gems/activesupport-7.2.2.1/lib/active_support/evented_file_update_checker.rb:3:in `<top (required)>'
	from /usr/local/lib/ruby/3.3.0/bundled_gems.rb:75:in `require'
	from /usr/local/lib/ruby/3.3.0/bundled_gems.rb:75:in `block (2 levels) in replace_require'
	from /usr/local/bundle/gems/zeitwerk-2.7.2/lib/zeitwerk/core_ext/kernel.rb:34:in `require'
	from /opt/app/config/environments/development.rb:63:in `block in <top (required)>'
```