### PR TITLE
Support: Whitelist @nista.gov.uk domain

### DIFF
--- a/app/lib/email_validator.rb
+++ b/app/lib/email_validator.rb
@@ -28,6 +28,7 @@ module EmailValidator
     return true if email.end_with? '@gpa.gov.uk'
     return true if email.end_with? '@ipa.gov.uk'
     return true if email.end_with? '@ibca.org.uk'
+    return true if email.end_with? '@nista.gov.uk'
     false
   end
 
@@ -43,6 +44,7 @@ module EmailValidator
       /([a-z0-9.\-\']+@cyberis\.com,?\s*)/,
       /([a-z0-9.\-\']+@pentestpartners\.com,?\s*)/,
       /([a-z0-9.\-\']+@ibca\.org\.uk,?\s*)/,
+      /([a-z0-9.\-\']+@nista\.gov\.uk,?\s*)/,
     )})+\z/
   end
 

--- a/test/lib/email_validator_test.rb
+++ b/test/lib/email_validator_test.rb
@@ -1,152 +1,65 @@
 require 'test_helper'
 
 class EmailValidatorTest < ActiveSupport::TestCase
-  test 'GDS email addresses are allowed to sign in' do
-    email = 'fname.lname@digital.cabinet-office.gov.uk'
-    assert EmailValidator.email_is_allowed_basic?(email)
+  # Domains allowed for basic sign-in
+  BASIC_ALLOWED_DOMAINS = %w[
+    digital.cabinet-office.gov.uk
+    cabinetoffice.gov.uk
+    gpa.gov.uk
+    ipa.gov.uk
+    softwire.com
+    fidusinfosec.com
+    cyberis.com
+    pentestpartners.com
+    ibca.org.uk
+    nista.gov.uk
+  ].freeze
+
+  # A subset of domains with advanced permissions to manage other users
+  ADVANCED_ALLOWED_DOMAINS = %w[
+    digital.cabinet-office.gov.uk
+    cabinetoffice.gov.uk
+    gpa.gov.uk
+    ipa.gov.uk
+    ibca.org.uk
+    nista.gov.uk
+  ].freeze
+
+  BASIC_ONLY_DOMAINS = BASIC_ALLOWED_DOMAINS - ADVANCED_ALLOWED_DOMAINS
+  DISALLOWED_DOMAIN = 'example.com'.freeze
+
+  test 'email_is_allowed_basic? correctly validates domains for sign-in' do
+    BASIC_ALLOWED_DOMAINS.each do |domain|
+      email = "fname.lname@#{domain}"
+      assert EmailValidator.email_is_allowed_basic?(email), "Expected #{domain} to be allowed for basic sign-in."
+    end
+
+    email = "fname.lname@#{DISALLOWED_DOMAIN}"
+    assert_not EmailValidator.email_is_allowed_basic?(email), "Expected #{DISALLOWED_DOMAIN} to be denied for basic sign-in."
   end
 
-  test 'Cabinet Office email addresses are allowed to sign in' do
-    email = 'fname.lname@cabinetoffice.gov.uk'
-    assert EmailValidator.email_is_allowed_basic?(email)
+  test 'email_is_allowed_advanced? correctly validates domains for user management' do
+    ADVANCED_ALLOWED_DOMAINS.each do |domain|
+      email = "fname.lname@#{domain}"
+      assert EmailValidator.email_is_allowed_advanced?(email), "Expected #{domain} to be allowed for user management."
+    end
+
+    (BASIC_ONLY_DOMAINS + [DISALLOWED_DOMAIN]).each do |domain|
+      email = "fname.lname@#{domain}"
+      assert_not EmailValidator.email_is_allowed_advanced?(email), "Expected #{domain} to be denied for user management."
+    end
   end
 
-  test 'Government Property Agency email addresses are allowed to sign in' do
-    email = 'fname.lname@gpa.gov.uk'
-    assert EmailValidator.email_is_allowed_basic?(email)
+  test 'allowed_emails_regexp matches all valid email patterns and rejects invalid ones' do
+    BASIC_ALLOWED_DOMAINS.each do |domain|
+      assert_match EmailValidator.allowed_emails_regexp, "fname.lname@#{domain}"
+      assert_match EmailValidator.allowed_emails_regexp, "fname.lname123@#{domain}"
+    end
+
+    assert_no_match EmailValidator.allowed_emails_regexp, "fname.lname@#{DISALLOWED_DOMAIN}"
   end
 
-  test 'Infrastructure and Projects Authority email addresses are allowed to sign in' do
-    email = 'fname.lname@ipa.gov.uk'
-    assert EmailValidator.email_is_allowed_basic?(email)
-  end
-
-  test 'Softwire email addresses are allowed to sign in' do
-    email = 'fname.lname@softwire.com'
-    assert EmailValidator.email_is_allowed_basic?(email)
-  end
-
-  test 'Fidusinfosec email addresses are allowed to sign in' do
-    email = 'fname.lname@fidusinfosec.com'
-    assert EmailValidator.email_is_allowed_basic?(email)
-  end
-
-  test 'Cyberis email addresses are allowed to sign in' do
-    email = 'fname.lname@cyberis.com'
-    assert EmailValidator.email_is_allowed_basic?(email)
-  end
-
-  test 'Pentestpartners email addresses are allowed to sign in' do
-    email = 'fname.lname@pentestpartners.com'
-    assert EmailValidator.email_is_allowed_basic?(email)
-  end
-
-  test 'IBCA email addresses are allowed to sign in' do
-    email = 'fname.lname@ibca.org.uk'
-    assert EmailValidator.email_is_allowed_basic?(email)
-  end
-
-  test 'Other email addresses are not allowed to sign in' do
-    email = 'fname.lname@example.com'
-    assert ! EmailValidator.email_is_allowed_basic?(email)
-  end
-
-  test 'GDS email addresses are allowed to manage users' do
-    email = 'fname.lname@digital.cabinet-office.gov.uk'
-    assert EmailValidator.email_is_allowed_advanced?(email)
-  end
-
-  test 'Cabinet Office email addresses are allowed to manage users' do
-    email = 'fname.lname@cabinetoffice.gov.uk'
-    assert EmailValidator.email_is_allowed_advanced?(email)
-  end
-
-  test 'Government Property Agency email addresses are allowed to manage users' do
-    email = 'fname.lname@gpa.gov.uk'
-    assert EmailValidator.email_is_allowed_advanced?(email)
-  end
-
-  test 'Infrastructure and Projects Authority email addresses are allowed to manage users' do
-    email = 'fname.lname@ipa.gov.uk'
-    assert EmailValidator.email_is_allowed_advanced?(email)
-  end
-
-  test 'IBCA email addresses are allowed to manage users' do
-    email = 'fname.lname@ibca.org.uk'
-    assert EmailValidator.email_is_allowed_advanced?(email)
-  end
-
-  test 'Softwire email addresses are not allowed to manage users' do
-    email = 'fname.lname@softwire.com'
-    assert ! EmailValidator.email_is_allowed_advanced?(email)
-  end
-
-  test 'Fidusinfosec email addresses are not allowed to manage users' do
-    email = 'fname.lname@fidusinfosec.com'
-    assert ! EmailValidator.email_is_allowed_advanced?(email)
-  end
-
-  test 'Cyberis email addresses are not allowed to manage users' do
-    email = 'fname.lname@cyberis.com'
-    assert ! EmailValidator.email_is_allowed_advanced?(email)
-  end
-
-  test 'Other email addresses are not allowed to manage users' do
-    email = 'fname.lname@example.com'
-    assert ! EmailValidator.email_is_allowed_advanced?(email)
-  end
-
-  test 'GDS emails are matched by the allowed emails regexp' do
-    email = 'fname.lname@digital.cabinet-office.gov.uk'
-    assert_match EmailValidator.allowed_emails_regexp, email
-  end
-
-  test 'Cabinet Office emails are matched by the allowed emails regexp' do
-    email = 'fname.lname@cabinetoffice.gov.uk'
-    assert_match EmailValidator.allowed_emails_regexp, email
-  end
-
-  test 'Government Property Agency emails can be used as usernames for new users' do
-    email = 'fname.lname@gpa.gov.uk'
-    assert_match EmailValidator.allowed_emails_regexp, email
-  end
-
-  test 'Infrastructure and Projects Authority emails can be used as usernames for new users' do
-    email = 'fname.lname@ipa.gov.uk'
-    assert_match EmailValidator.allowed_emails_regexp, email
-  end
-
-  test 'Softwire emails are matched by the allowed emails regexp' do
-    email = 'fname.lname@softwire.com'
-    assert_match EmailValidator.allowed_emails_regexp, email
-  end
-
-  test 'Fidusinfosec emails are matched by the allowed emails regexp' do
-    email = 'fname.lname@fidusinfosec.com'
-    assert_match EmailValidator.allowed_emails_regexp, email
-  end
-
-  test 'Cyberis emails are matched by the allowed emails regexp' do
-    email = 'fname.lname@cyberis.com'
-    assert_match EmailValidator.allowed_emails_regexp, email
-  end
-
-  test 'Pentestpartners emails are matched by the allowed emails regexp' do
-    email = 'fname.lname@pentestpartners.com'
-    assert_match EmailValidator.allowed_emails_regexp, email
-  end
-
-  test 'IBCA emails are matched by the allowed emails regexp' do
-    email = 'fname.lname@ibca.org.uk'
-    assert_match EmailValidator.allowed_emails_regexp, email
-  end
-
-  test 'Emails with numbers in the local part are allowed' do
-    email = 'fname.lname1@digital.cabinet-office.gov.uk'
-    assert_match EmailValidator.allowed_emails_regexp, email
-  end
-
-  test 'Mixed list of valid emails are matched by the allowed emails regexp' do
+  test 'mixed list of valid emails are matched by the allowed emails regexp' do
     emails = [
       'test.user@digital.cabinet-office.gov.uk',
       'test.user@cabinetoffice.gov.uk',
@@ -154,32 +67,26 @@ class EmailValidatorTest < ActiveSupport::TestCase
     assert_match EmailValidator.allowed_emails_regexp, emails
   end
 
-  test 'Other email addresses should not match emails regexp' do
-    email = 'fname.lname@example.com'
-    assert_no_match EmailValidator.allowed_emails_regexp, email
-  end
-
   test "If ENV['RESTRICT_LOGIN_EMAIL_ADDRESSES_TO'] is set then only allow the specified emails to login" do
     allowed_address = 'allowed.person@digital.cabinet-office.gov.uk'
-    assert EmailValidator.email_is_allowed_basic?(allowed_address)
-    assert EmailValidator.email_is_allowed_basic?('notallowed.person@digital.cabinet-office.gov.uk')
-    assert EmailValidator.email_is_allowed_advanced?(allowed_address)
-    assert EmailValidator.email_is_allowed_advanced?('notallowed.person@digital.cabinet-office.gov.uk')
+    disallowed_address = 'notallowed.person@digital.cabinet-office.gov.uk'
 
-    # blank string is ignored
+    assert EmailValidator.email_is_allowed_basic?(allowed_address)
+    assert EmailValidator.email_is_allowed_basic?(disallowed_address)
+    assert EmailValidator.email_is_allowed_advanced?(allowed_address)
+    assert EmailValidator.email_is_allowed_advanced?(disallowed_address)
+
     ENV['RESTRICT_LOGIN_EMAIL_ADDRESSES_TO'] = " "
     assert EmailValidator.email_is_allowed_basic?(allowed_address)
-    assert EmailValidator.email_is_allowed_basic?('notallowed.person@digital.cabinet-office.gov.uk')
-    assert EmailValidator.email_is_allowed_advanced?(allowed_address)
-    assert EmailValidator.email_is_allowed_advanced?('notallowed.person@digital.cabinet-office.gov.uk')
+    assert EmailValidator.email_is_allowed_basic?(disallowed_address)
 
     ENV['RESTRICT_LOGIN_EMAIL_ADDRESSES_TO'] = allowed_address
     assert EmailValidator.email_is_allowed_basic?(allowed_address)
-    assert ! EmailValidator.email_is_allowed_basic?('notallowed.person@digital.cabinet-office.gov.uk')
+    assert_not EmailValidator.email_is_allowed_basic?(disallowed_address)
     assert EmailValidator.email_is_allowed_advanced?(allowed_address)
-    assert ! EmailValidator.email_is_allowed_advanced?('notallowed.person@digital.cabinet-office.gov.uk')
+    assert_not EmailValidator.email_is_allowed_advanced?(disallowed_address)
 
-    # cleanup
+  ensure
     ENV.delete('RESTRICT_LOGIN_EMAIL_ADDRESSES_TO')
   end
 end


### PR DESCRIPTION
Whitelists `@nista.gov.uk` domain and grants advanced permissions (same as `ipa.gov.uk` since this is a MOG change)

Also refactors `email_validator_test.rb` to be more data driven and easier to maintain