### PR TITLE
npm ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:24.7-alpine AS nodebuilder
 WORKDIR /opt/app
 COPY package-lock.json ./
 COPY package.json ./
-RUN npm i
+RUN npm ci
 
 # bundle install the gems for production
 FROM ruby:3.3.5-alpine AS rubybuilder


### PR DESCRIPTION
For reproducibility & security. `npm ci` uses only package-lock.json for its deps, whereas `npm i` does more figuring out from package.json