### PR TITLE
bau-bump-rack-session

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'csv'
 gem 'ostruct'
 gem 'jwt', '~> 3.1.2'
 gem 'puma', '~>7.2.0'
+gem 'rack-session', '~>2.1.2'
 
 group :test do
   gem 'rack_session_access', '~> 0.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1860,7 +1860,7 @@ GEM
       base64 (>= 0.1.0)
       logger (>= 1.6.0)
       rack (>= 3.0.0, < 4)
-    rack-session (2.1.1)
+    rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
     rack-test (2.2.0)
@@ -1990,6 +1990,7 @@ DEPENDENCIES
   ostruct
   pry
   puma (~> 7.2.0)
+  rack-session (~> 2.1.2)
   rack_session_access (~> 0.2.0)
   rails (~> 7.2.3)
   rexml (~> 3.4.4)


### PR DESCRIPTION
explicity bump rack-session to 2.1.2. dependabot, for some reason, is unable to do this