### PR TITLE
Upgrade to GOV.UK Frontend 6 and migrated to Dart Sass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,9 @@ yarn-error.log
 # emacs 
 .#*
 *.*#
+
+# Dart Sass
+/app/assets/builds/*
+!/app/assets/builds/.keep
+/app/assets/builds/*
+!/app/assets/builds/.keep

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'octokit', '~> 10.0.0'
 gem 'omniauth-google-oauth2', '~> 1.2.2'
 gem 'omniauth-rails_csrf_protection', '~> 2.0.1'
 gem 'rails', '~> 7.2.3'
-gem 'sassc-rails'
+gem 'sprockets-rails', '~> 3.5.2'
 gem 'webmock', '~> 3.26.2'
 gem 'aws-sdk', '~> 3'
 gem 'rexml', '~> 3.4.4'
@@ -29,3 +29,5 @@ end
 gem "listen", "~> 3.10", :group => :development
 gem "pry"
 gem "slop"
+
+gem "dartsass-rails", "~> 0.5.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1713,6 +1713,9 @@ GEM
       rexml
     crass (1.0.6)
     csv (3.3.5)
+    dartsass-rails (0.5.1)
+      railties (>= 6.0.0)
+      sass-embedded (~> 1.63)
     date (3.4.1)
     dotenv (3.2.0)
     dotenv-rails (3.2.0)
@@ -1739,6 +1742,33 @@ GEM
     ffi (1.17.3-x86_64-linux-musl)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    google-protobuf (4.35.0)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-aarch64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-aarch64-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-arm64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-x86-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-x86-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-x86_64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-x86_64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-x86_64-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
     hashdiff (1.2.1)
     hashie (5.1.0)
       logger
@@ -1914,14 +1944,25 @@ GEM
     request_store (1.7.0)
       rack (>= 1.4)
     rexml (3.4.4)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
+    sass-embedded (1.100.0)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
+    sass-embedded (1.100.0-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
@@ -1930,8 +1971,9 @@ GEM
     snaky_hash (2.0.3)
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
-    sprockets (4.2.1)
+    sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
+      logger
       rack (>= 2.2.4, < 4)
     sprockets-rails (3.5.2)
       actionpack (>= 6.1)
@@ -1939,7 +1981,6 @@ GEM
       sprockets (>= 3.0.0)
     stringio (3.1.9)
     thor (1.4.0)
-    tilt (2.4.0)
     timeout (0.6.1)
     tsort (0.2.0)
     tzinfo (2.0.6)
@@ -1978,6 +2019,7 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk (~> 3)
   csv
+  dartsass-rails (~> 0.5.1)
   dotenv-rails (~> 3.2.0)
   jwt (~> 3.2.0)
   listen (~> 3.10)
@@ -1994,8 +2036,8 @@ DEPENDENCIES
   rack_session_access (~> 0.2.0)
   rails (~> 7.2.3)
   rexml (~> 3.4.4)
-  sassc-rails
   slop
+  sprockets-rails (~> 3.5.2)
   tzinfo-data
   webmock (~> 3.26.2)
 

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bin/rails server -p 3000
+css: bin/rails dartsass:watch

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,7 +1,7 @@
 //= link application.js
+//= link application.css
 //
 //= link_tree ../images
 //
-//= link_directory ../stylesheets .css
-//
 //= link_tree ../../../node_modules/govuk-frontend/dist/govuk/assets
+//= link_tree ../builds

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,7 +1,10 @@
-$govuk-global-styles: true;
-$govuk-images-path: "govuk-frontend/govuk/assets/images/";
-$govuk-font-family: arial, sans-serif;
-@import "govuk-frontend/dist/govuk/all";
+$font-family: arial, sans-serif;
+
+@use "govuk-frontend/dist/govuk" as * with (
+  $govuk-global-styles: true,
+  $govuk-font-family: $font-family,
+  $govuk-assets-path: "/assets/govuk-frontend/dist/govuk/assets/"
+);
 
 .govuk-header__product-name {
   width: 150%;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,7 @@
 
   <body class="govuk-template__body">
      <%= javascript_tag nonce: true do %>
-      document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+      document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
     <% end %>
 
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+if ! gem list foreman -i --silent; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+exec foreman start -f Procfile.dev "$@"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,13 +6,14 @@
     "": {
       "name": "re-request-an-aws-account",
       "dependencies": {
-        "govuk-frontend": "^5.14.0"
+        "govuk-frontend": "^6.2.0"
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.14.0.tgz",
-      "integrity": "sha512-MgfaXswIM6KpXS2T5gltEnzgVLgfM3UoE9+rYkhBiR0suaJ8Let31VZXQZqz9QhiPDbv28fW1nRjIyLujfZIBA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.2.0.tgz",
+      "integrity": "sha512-PCRyQT+7kiV2dUz0Ku6Co+Nx4anOwJ7mAduXYbTQHK2krppBSynv9dBXtOYha/8j+LIzK7FqesTbJl9HD6ekHg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -20,9 +21,9 @@
   },
   "dependencies": {
     "govuk-frontend": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.14.0.tgz",
-      "integrity": "sha512-MgfaXswIM6KpXS2T5gltEnzgVLgfM3UoE9+rYkhBiR0suaJ8Let31VZXQZqz9QhiPDbv28fW1nRjIyLujfZIBA=="
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.2.0.tgz",
+      "integrity": "sha512-PCRyQT+7kiV2dUz0Ku6Co+Nx4anOwJ7mAduXYbTQHK2krppBSynv9dBXtOYha/8j+LIzK7FqesTbJl9HD6ekHg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "re-request-an-aws-account",
   "dependencies": {
-    "govuk-frontend": "^5.14.0"
+    "govuk-frontend": "^6.2.0"
   }
 }


### PR DESCRIPTION
GOV.UK Frontend no longer supports libsass and so had to move rails to use Dart Sass via the dartsass-rails gem.

Currently deployed at https://request-an-aws-user-test.digital.cabinet-office.gov.uk/ 
