### PR TITLE
chore: make local running easier with docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+export RUBY_VERSION := $(shell cat .ruby-version)
+export NODE_VERSION := $(shell cat .node-version)
+export PLATFORM ?= linux/$(shell uname -m)
+
+.PHONY: install build serve test docker-build docker-serve docker-up docker-down
+
+install:
+	bundle install
+	npm ci
+
+build:
+	bundle exec rake dartsass:build
+
+serve: build
+	bundle exec rails server
+
+test:
+	bundle exec rails test
+
+docker-build:
+	docker-compose build
+
+docker-build-amd64:
+	PLATFORM=linux/amd64 docker-compose build
+
+docker-serve:
+	docker-compose up
+
+docker-up:
+	docker-compose up --build
+
+docker-down:
+	docker-compose down

--- a/README.md
+++ b/README.md
@@ -8,8 +8,16 @@ This is a rails app, with dependencies managed by bundler. To run the app
 locally clone this repo, then:
 
 ```sh
+make install
+make serve
+```
+
+Or manually:
+
+```sh
 bundle install
 npm install
+bundle exec rake dartsass:build
 bundle exec rails server
 ```
 
@@ -26,6 +34,12 @@ $EDITOR .env
 Run the tests with:
 
 ```sh
+make test
+```
+
+Or manually:
+
+```sh
 bundle exec rails test
 ```
 
@@ -34,11 +48,28 @@ try different email addresses, you can provide a `email` parameter). If you want
 to test with real Google SSO, you can
 [create an application in the Google Cloud Console](https://console.developers.google.com/apis/credentials).
 
-## Building Docker Image
+## Running with Docker
 
-Note - when building the docker image on a mac arm but wanting to run the image
-on x86 architecture then run the `docker build` with this flag:
-`--platform="linux/amd64"`
+To build and run the app in Docker locally:
+
+```sh
+make docker-build
+make docker-up
+```
+
+To stop the container:
+
+```sh
+make docker-down
+```
+
+> [!NOTE]
+> The platform is auto-detected via `uname -m`. If you need to build for a
+> different target platform (e.g. building on a Mac ARM for x86) override it with:
+
+```sh
+make docker-build PLATFORM=linux/amd64
+```
 
 ## Ruby App Master Key
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  web:
+    build:
+      context: .
+      args:
+        RUBY_VERSION: ${RUBY_VERSION}
+        NODE_VERSION: ${NODE_VERSION}
+    platform: ${PLATFORM:-}
+    image: re-request-aws-test
+    ports:
+      - "3000:3000"
+    environment:
+      - RAILS_SERVE_STATIC_FILES=true
+      - RAILS_LOG_TO_STDOUT=true
+      - SECRET_KEY_BASE=dummy
+      - RAILS_MASTER_KEY=dummy
+    env_file:
+      - path: .env
+        required: false


### PR DESCRIPTION
In order to mitigate issues due bumps to the Alpine base image, and to the Ruby minor version, node version number, a while ago some changes were made to ensure a single source of truth for managing version changes mainly by specifying versions in one location such as ruby-version, node-version and referencing these wherever they are needed such as in gemspec, dockerfile this solved the problem. 
However the dockerfile used ARG in the dockerfile and they are deliberately **not optional**

The above changes mean't dev's could no longer use docker to run the app easily previous you could just do

```
docker build -t re-request-aws-test .
docker run -p 3000:3000 re-request-aws-test
```

but now you would have to do the below, due to the above changes to the dockerfile

```
docker build --build-arg RUBY_VERSION=$(cat .ruby-version) --build-arg NODE_VERSION=$(cat .node-version) -t re-request-aws-test  .
docker run -p 3000:3000 re-request-aws-test
```

The changes in this PR now restores the ability to easily use docker instead, it uses a makefile to abstract different use cases based on developer preferences

Now if you want to use docker to run the app, you could just do the following if you had docker running and don't want  install ruby

`make docker-up`

For more granular options, please see the README.md


